### PR TITLE
Add scripts to help with interfacing with the FTDI chip

### DIFF
--- a/scripts/larpix-drivercheck-mac
+++ b/scripts/larpix-drivercheck-mac
@@ -20,7 +20,7 @@ download_location = os.path.expanduser('~/Downloads')
 if os.path.isdir(expected_location):
     print('The driver is installed at ' + expected_location + '.')
     print('Try restarting your computer if you are still'
-            'having issues finding the FTDI device.')
+            ' having issues finding the FTDI device.')
     sys.exit(0)
 
 print('Could not find the FTDI driver at ' + expected_location +
@@ -35,7 +35,7 @@ if should_download in 'Nn' or should_download == '':
             '. You should most likely pick the Mac OS X 10.9 and above'
             ' version.')
 elif should_download in 'Yy':
-    print('OK, downloading from ' + dmg_url + '.')
+    print('OK, downloading from ' + dmg_url + '.\n')
     try:
         subprocess.check_call(['wget', '--version'], stdout=open('/dev/null'))
         has_wget = True

--- a/scripts/larpix-drivercheck-mac
+++ b/scripts/larpix-drivercheck-mac
@@ -13,7 +13,7 @@ import os
 import sys
 
 # Check to see if the FTDI kext file is located in the correct place
-expected_location = '/System/Library/Extensions/FTDIUSBSerialDriver.kext'
+expected_location = '/Library/Extensions/FTDIUSBSerialDriver.kext'
 webpage = 'http://www.ftdichip.com/Drivers/VCP.htm'
 dmg_url = 'http://www.ftdichip.com/Drivers/VCP/MacOSX/FTDIUSBSerialDriver_v2_4_2.dmg'
 download_location = os.path.expanduser('~/Downloads')

--- a/scripts/larpix-drivercheck-mac
+++ b/scripts/larpix-drivercheck-mac
@@ -1,0 +1,61 @@
+#!/env/python
+# This script checks to see if your Mac computer has the correct driver
+# installed.
+from __future__ import print_function
+import argparse
+
+parser = argparse.ArgumentParser(description='Check to see if you need'
+        ' to install the FTDI driver. Only use on Mac computers.')
+args = parser.parse_args()
+
+import subprocess
+import os
+import sys
+
+# Check to see if the FTDI kext file is located in the correct place
+expected_location = '/System/Library/Extensions/FTDIUSBSerialDriver.kext'
+webpage = 'http://www.ftdichip.com/Drivers/VCP.htm'
+dmg_url = 'http://www.ftdichip.com/Drivers/VCP/MacOSX/FTDIUSBSerialDriver_v2_4_2.dmg'
+download_location = os.path.expanduser('~/Downloads')
+if os.path.isdir(expected_location):
+    print('The driver is installed at ' + expected_location + '.')
+    print('Try restarting your computer if you are still'
+            'having issues finding the FTDI device.')
+    sys.exit(0)
+
+print('Could not find the FTDI driver at ' + expected_location +
+        ', which is the expected install location. I can download'
+        ' the driver for you to install.\n')
+should_download = 'A'
+while should_download not in 'YyNn' and should_download != '':
+    should_download = input('Should I download the driver to ' +
+             download_location + '? [y/N] ')
+if should_download in 'Nn' or should_download == '':
+    print('\nOK. You can download the driver yourself at ' + webpage +
+            '. You should most likely pick the Mac OS X 10.9 and above'
+            ' version.')
+elif should_download in 'Yy':
+    print('OK, downloading from ' + dmg_url + '.')
+    try:
+        subprocess.check_call(['wget', '--version'], stdout=open('/dev/null'))
+        has_wget = True
+    except subprocess.CalledProcessError:
+        has_wget = False
+    if has_wget:
+        subprocess.call(['wget', '-P' + download_location,
+            dmg_url])
+    else:
+        subprocess.call(['curl', dmg_url],
+                stdout=open(download_location, 'w'))
+print('''
+
+Once the .dmg is downloaded, open it up and run the installer. You will
+likely have to restart your computer before the driver will load
+correctly. You will know it works when, after plugging in an FTDI device
+(e.g. the FPGA board), you see at least one "file" named something like
+
+cu.usbserial-xxxxxxx
+
+in the /dev directory of your computer. You can check for this by
+yourself or by running the larpix-find-device-mac command.\
+''')

--- a/scripts/larpix-drivercheck-ubuntu
+++ b/scripts/larpix-drivercheck-ubuntu
@@ -50,7 +50,7 @@ if not has_ftdi:
         print('\nOK. You can download the driver yourself at ' + webpage +
                 '. You should most likely pick the 64-bit version.')
     elif should_download in 'Yy':
-        print('OK, downloading from ' + dmg_url + '.')
+        print('OK, downloading from ' + dmg_url + '.\n')
         try:
             subprocess.check_call(['wget', '--version'], stdout=open('/dev/null'))
             has_wget = True

--- a/scripts/larpix-drivercheck-ubuntu
+++ b/scripts/larpix-drivercheck-ubuntu
@@ -1,0 +1,77 @@
+#!/env/python
+# This script checks to see if the ftdi_sio module is present on your
+# computer.
+from __future__ import print_function
+import argparse
+
+parser = argparse.ArgumentParser(description='Check to see if you need'
+        ' to install the FTDI driver. Only use on Ubuntu and similar'
+        ' computers.')
+args = parser.parse_args()
+
+import subprocess
+import os
+import sys
+
+p1 = subprocess.Popen(['lsmod'], stdout=subprocess.PIPE)
+p2 = subprocess.Popen(['grep', '-c','ftdi_sio'], stdin=p1.stdout,
+        stdout=subprocess.PIPE)
+p1.stdout.close()
+result_ftdi_sio = p2.communicate()[0]
+
+p1 = subprocess.Popen(['lsmod'], stdout=subprocess.PIPE)
+p2 = subprocess.Popen(['grep', '-c','usbserial'], stdin=p1.stdout,
+        stdout=subprocess.PIPE)
+p1.stdout.close()
+result_usbserial = p2.communicate()[0]
+has_ftdi = int(result_ftdi_sio) > 0
+has_usbserial = int(result_usbserial) > 0
+if not has_ftdi:
+    print('Could not find the ftdi_sio driver.')
+if not has_usbserial:
+    print('Could not find the usbserial driver.')
+if has_ftdi and has_usbserial:
+    print('Found all required modules. Try restarting your computer'
+            ' if you are still having issues finding the FTDI device.')
+    sys.exit(0)
+
+print('Could not find at least one of the appropriate drivers.\n')
+if not has_usbserial:
+    print("To install usbserial, you're on your own. Sorry.")
+if not has_ftdi:
+    webpage = 'http://www.ftdichip.com/Drivers/VCP.htm'
+    dmg_url = 'http://www.ftdichip.com/Drivers/VCP/Linux/ftdi_sio.tar.gz'
+    download_location = os.path.expanduser('~/Downloads')
+    should_download = 'A'
+    while should_download not in 'YyNn' and should_download != '':
+        should_download = input('Should I download the driver to ' +
+                 download_location + '? [y/N] ')
+    if should_download in 'Nn' or should_download == '':
+        print('\nOK. You can download the driver yourself at ' + webpage +
+                '. You should most likely pick the 64-bit version.')
+    elif should_download in 'Yy':
+        print('OK, downloading from ' + dmg_url + '.')
+        try:
+            subprocess.check_call(['wget', '--version'], stdout=open('/dev/null'))
+            has_wget = True
+        except subprocess.CalledProcessError:
+            has_wget = False
+        if has_wget:
+            subprocess.call(['wget', '-P' + download_location,
+                dmg_url])
+        else:
+            subprocess.call(['curl', dmg_url],
+                    stdout=open(download_location, 'w'))
+
+print('''
+
+Once the .dmg is downloaded, open it up and run the installer. You will
+likely have to restart your computer before the driver will load
+correctly. You will know it works when, after plugging in an FTDI device
+(e.g. the FPGA board), you see at least one "file" named something like
+
+cu.usbserial-xxxxxxx
+
+in the /dev directory of your computer. You can check for this by
+yourself or by running the larpix-find-device-mac command.\
+''')

--- a/scripts/larpix-find-device-mac
+++ b/scripts/larpix-find-device-mac
@@ -1,0 +1,23 @@
+#!/env/python
+# This script will look for devices in /dev that look like the correct
+# FTDI device.
+from __future__ import print_function
+import argparse
+
+parser = argparse.ArgumentParser(description='Look for devices in'
+        ' /dev that look like the correct FTDI device for larpix.'
+        ' This version works on Mac computers only. For Ubuntu and'
+        ' related Linux computers, use larpix-find-device-ubuntu.')
+args = parser.parse_args()
+
+import os
+import re
+
+# This is the pattern we're looking for
+pattern = re.compile(r'^cu\.usbserial.*$')
+
+# Get the list of files in the /dev directory
+files = os.listdir('/dev')
+for filename in files:
+    if pattern.match(filename):
+        print(filename)

--- a/scripts/larpix-find-device-ubuntu
+++ b/scripts/larpix-find-device-ubuntu
@@ -1,0 +1,23 @@
+#!/env/python
+# This script will look for devices in /dev that look like the correct
+# FTDI device.
+from __future__ import print_function
+import argparse
+
+parser = argparse.ArgumentParser(description='Look for devices in'
+        ' /dev that look like the correct FTDI device for larpix.'
+        ' This version works on Ubuntu and related computers only.'
+        ' For Macs, use larpix-find-device-mac.')
+args = parser.parse_args()
+
+import os
+import re
+
+# This is the pattern we're looking for
+pattern = re.compile(r'^ttyUSB.*$')
+
+# Get the list of files in the /dev directory
+files = os.listdir('/dev')
+for filename in files:
+    if pattern.match(filename):
+        print(filename)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
         name='larpix-control',
-        version='0.3.1.dev0',
+        version='0.4.1.dev0',
         description='Control the LArPix chip',
         long_description=long_description,
         url='https://github.com/samkohn/larpix-control',
@@ -29,4 +29,8 @@ setup(
         keywords='dune physics',
         packages=['larpix'],
         install_requires=['pyserial','bitstring','pytest'],
+        scripts=['scripts/larpix-drivercheck-ubuntu',
+                 'scripts/larpix-drivercheck-mac',
+                 'scripts/larpix-find-device-ubuntu',
+                 'scripts/larpix-find-device-mac'],
 )


### PR DESCRIPTION
I created 4 scripts: 2 for Mac and 2 for Ubuntu/Debian Linux. Therre's a script which verifies the FTDI driver is installed (`larpix-drivercheck-*`) and a script which finds the correct `/dev/xxxx` port to connect to (`larpix-find-device-*`). This would complete Issue #11 