### PR TITLE
Export data to disk

### DIFF
--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -48,8 +48,6 @@ class Chip(object):
 
         '''
         data = {}
-        data['unix_timestamp'] = time.time()
-        data['timestamp'] = time.ctime()
         data['chipid'] = self.chip_id
         data['io_chain'] = self.io_chain
         if only_new_reads:

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -23,6 +23,7 @@ class Chip(object):
         self.data_to_send = []
         self.config = Configuration()
         self.reads = []
+        self.new_reads_index = 0
 
     def get_configuration_packets(self, packet_type):
         conf = self.config
@@ -36,13 +37,18 @@ class Chip(object):
             packet.assign_parity()
         return packets
 
-    def export_reads(self):
+    def export_reads(self, only_new_reads=True):
         data = {}
         data['unix_timestamp'] = time.time()
         data['timestamp'] = time.ctime()
         data['chipid'] = self.chip_id
         data['io_chain'] = self.io_chain
-        data['packets'] = list(map(lambda x:x.export(), self.reads))
+        if only_new_reads:
+            packets = self.reads[self.new_reads_index:]
+        else:
+            packets = self.reads
+        data['packets'] = list(map(lambda x:x.export(), packets))
+        self.new_reads_index = len(self.reads)
         return data
 
 class Configuration(object):

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -38,6 +38,15 @@ class Chip(object):
         return packets
 
     def export_reads(self, only_new_reads=True):
+        '''
+        Return a dict of the packets this Chip has received.
+
+        If ``only_new_reads`` is ``True`` (default), then only the
+        packets since the last time this method was called will be in
+        the dict. Otherwise, all of the packets stored in ``self.reads``
+        will be in the dict.
+
+        '''
         data = {}
         data['unix_timestamp'] = time.time()
         data['timestamp'] = time.ctime()

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -766,8 +766,6 @@ class Controller(object):
     def save_output(self, filename):
         '''Save the data read by each chip to the specified file.'''
         data = {}
-        data['unix_timestamp'] = time.time()
-        data['timestamp'] = time.ctime()
         data['chips'] = list(map(lambda x:x.export_reads(), self.chips))
         with open(filename, 'w') as outfile:
             json.dump(data, outfile, indent=4,

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -149,6 +149,21 @@ def test_chip_export_reads_all():
     assert result == expected
     assert chip.new_reads_index == 1
 
+def test_controller_save_output(tmpdir):
+    controller = Controller(None)
+    chip = Chip(1, 0)
+    p = Packet()
+    chip.reads.append(p)
+    controller.chips.append(chip)
+    name = str(tmpdir.join('test.json'))
+    controller.save_output(name)
+    with open(name) as f:
+        result = json.load(f)
+    expected = {
+            'chips': [chip.export_reads(only_new_reads=False)]
+            }
+    assert result == expected
+
 def test_packet_bits_bytes():
     assert Packet.num_bytes == Packet.size // 8 + 1
 

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -202,6 +202,86 @@ def test_packet_bytes_properties():
     b = p.bytes()
     assert b == expected
 
+def test_packet_export_test():
+    p = Packet()
+    p.packet_type = Packet.TEST_PACKET
+    p.chipid = 5
+    p.test_counter = 32838
+    p.assign_parity()
+    result = p.export()
+    expected = {
+            'bits': p.bits.bin,
+            'type': 'test',
+            'chipid': 5,
+            'counter': 32838,
+            'parity': p.parity_bit_value,
+            'valid_parity': True,
+            }
+    assert result == expected
+
+def test_packet_export_data():
+    p = Packet()
+    p.packet_type = Packet.DATA_PACKET
+    p.chipid = 2
+    p.channel_id = 10
+    p.timestamp = 123456
+    p.dataword = 180
+    p.fifo_half_flag = True
+    p.fifo_full_flag = False
+    p.assign_parity()
+    result = p.export()
+    expected = {
+            'bits': p.bits.bin,
+            'type': 'data',
+            'chipid': 2,
+            'channel': 10,
+            'timestamp': 123456,
+            'adc_counts': 180,
+            'fifo_half': True,
+            'fifo_full': False,
+            'parity': p.parity_bit_value,
+            'valid_parity': True,
+            }
+    assert result == expected
+
+def test_packet_export_config_read():
+    p = Packet()
+    p.packet_type = Packet.CONFIG_READ_PACKET
+    p.chipid = 10
+    p.register_address = 51
+    p.register_data = 2
+    p.assign_parity()
+    result = p.export()
+    expected = {
+            'bits': p.bits.bin,
+            'type': 'config read',
+            'chipid': 10,
+            'register': 51,
+            'value': 2,
+            'parity': p.parity_bit_value,
+            'valid_parity': True,
+            }
+    assert result == expected
+
+def test_packet_export_config_write():
+    p = Packet()
+    p.packet_type = Packet.CONFIG_WRITE_PACKET
+    p.chipid = 10
+    p.register_address = 51
+    p.register_data = 2
+    p.assign_parity()
+    result = p.export()
+    expected = {
+            'bits': p.bits.bin,
+            'type': 'config write',
+            'chipid': 10,
+            'register': 51,
+            'value': 2,
+            'parity': p.parity_bit_value,
+            'valid_parity': True,
+            }
+    assert result == expected
+
 def test_packet_set_packet_type():
     p = Packet()
     p.packet_type = Packet.DATA_PACKET

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -82,6 +82,73 @@ def test_chip_get_configuration_packets():
     assert packet.register_address == 40
     assert packet.register_data == 255
 
+def test_chip_export_reads():
+    chip = Chip(1, 2)
+    packet = Packet()
+    packet.packet_type = Packet.CONFIG_WRITE_PACKET
+    packet.chipid = 1
+    packet.register_address = 10
+    packet.register_data = 20
+    packet.assign_parity()
+    chip.reads.append(packet)
+    result = chip.export_reads()
+    expected = {
+            'chipid': 1,
+            'io_chain': 2,
+            'packets': [
+                {
+                    'bits': packet.bits.bin,
+                    'type': 'config write',
+                    'chipid': 1,
+                    'parity': 1,
+                    'valid_parity': True,
+                    'register': 10,
+                    'value': 20
+                    }
+                ]
+            }
+    assert result == expected
+    assert chip.new_reads_index == 1
+
+def test_chip_export_reads_no_new_reads():
+    chip = Chip(1, 2)
+    result = chip.export_reads()
+    expected = {'chipid': 1, 'io_chain': 2, 'packets': []}
+    assert result == expected
+    assert chip.new_reads_index == 0
+    packet = Packet()
+    packet.packet_type = Packet.CONFIG_WRITE_PACKET
+    chip.reads.append(packet)
+    chip.export_reads()
+    result = chip.export_reads()
+    assert result == expected
+    assert chip.new_reads_index == 1
+
+def test_chip_export_reads_all():
+    chip = Chip(1, 2)
+    packet = Packet()
+    packet.packet_type = Packet.CONFIG_WRITE_PACKET
+    chip.reads.append(packet)
+    chip.export_reads()
+    result = chip.export_reads(only_new_reads=False)
+    expected = {
+            'chipid': 1,
+            'io_chain': 2,
+            'packets': [
+                {
+                    'bits': packet.bits.bin,
+                    'type': 'config write',
+                    'chipid': 0,
+                    'parity': 0,
+                    'valid_parity': True,
+                    'register': 0,
+                    'value': 0
+                    }
+                ]
+            }
+    assert result == expected
+    assert chip.new_reads_index == 1
+
 def test_packet_bits_bytes():
     assert Packet.num_bytes == Packet.size // 8 + 1
 


### PR DESCRIPTION
This PR creates a bunch of "export" methods, the end result of which is to allow `Controller.save_output` to save all of the output collected in each chip's `reads` list into a JSON file. As a bonus I included the appropriate unit tests and docstrings for each of the new methods I created.