### PR TITLE
Bench test additions: periodic reset test, --verbose, and a log message

### DIFF
--- a/larpix/benchtest.py
+++ b/larpix/benchtest.py
@@ -11,10 +11,14 @@ from bitstring import BitArray
 
 def setup_logger(settings):
     logger = logging.getLogger(__name__)
-    logger.setLevel(logging.INFO)
+    if settings['verbose']:
+        level = logging.DEBUG
+    else:
+        level = logging.INFO
+    logger.setLevel(level)
     logfile = settings['logfile']
     handler = logging.FileHandler(logfile)
-    handler.setLevel(logging.INFO)
+    handler.setLevel(level)
     formatter = logging.Formatter('[%(asctime)s] %(levelname)s: '
             '%(message)s')
     handler.setFormatter(formatter)
@@ -291,6 +295,8 @@ if __name__ == '__main__':
             help='filename to save data to')
     parser.add_argument('-m', '--message', default='',
             help='message to save to the logfile')
+    parser.add_argument('-v', '--verbose', action='store_true',
+            help='print debug messages as well')
     args = parser.parse_args()
     if args.list:
         print('\n'.join(tests.keys()))
@@ -304,6 +310,7 @@ if __name__ == '__main__':
             'chipset': chipset,
             'logfile': args.logfile,
             'filename': args.filename,
+            'verbose': args.verbose
             }
     setup_logger(settings)
     logger = logging.getLogger(__name__)

--- a/larpix/benchtest.py
+++ b/larpix/benchtest.py
@@ -289,6 +289,8 @@ if __name__ == '__main__':
             help='list of IO chain IDs (corresponding to chipids')
     parser.add_argument('-f', '--filename', default='out.txt',
             help='filename to save data to')
+    parser.add_argument('-m', '--message', default='',
+            help='message to save to the logfile')
     args = parser.parse_args()
     if args.list:
         print('\n'.join(tests.keys()))
@@ -305,6 +307,8 @@ if __name__ == '__main__':
             }
     setup_logger(settings)
     logger = logging.getLogger(__name__)
+    logger.info('-'*60)
+    logger.info(args.message)
     try:
         for test in args.test:
             tests[test](settings)


### PR DESCRIPTION
Add a periodic reset test which iterates through a wide range of periodic reset intervals and expects data to be triggered by an external trigger.

Add a `--verbose` option to the command line to include debug statements in the log.

Add a `-m` option to include a custom log message along with all of the automatically-logged messages.