### PR TITLE
Update Configuration object based on actual config read packets

### DIFF
--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -118,6 +118,11 @@ class Configuration(object):
     TEST_UART = 0x1
     TEST_FIFO = 0x2
     def __init__(self):
+        # Actual setup
+        self.load('default.json')
+
+        # Annoying things we have to do because the configuration
+        # register follows complex semantics
         self.register_names = ['pixel_trim_thresholds',
                                'global_threshold',
                                'csa_gain',
@@ -137,7 +142,50 @@ class Configuration(object):
                                'channel_mask',
                                'external_trigger_mask',
                                'reset_cycles']
-        self.load('default.json')
+        # The following dicts/lists specify how to translate a register
+        # address into a sensible update to the Configuration object.
+        # Simple registers are just the value stored in the register.
+        self._simple_registers = {
+                32: 'global_threshold',
+                46: 'csa_testpulse_dac_amplitude',
+                48: 'sample_cycles',
+                51: 'adc_burst_length',
+                }
+        # These registers need the attribute extracted from the register
+        # data.
+        self._complex_modify_data = {
+                33: [('csa_gain', lambda data:data % 2),
+                     ('csa_bypass', lambda data:(data//2) % 2),
+                     ('internal_bypass', lambda data:(data//8) % 2)]
+                47: [('test_mode', lambda data:data % 4),
+                     ('cross_trigger_mode', lambda data:(data//4) % 2),
+                     ('periodic_reset', lambda data:(data//8) % 2),
+                     ('fifo_diagnostic', lambda data(data//16) % 2)]
+                }
+        # These registers combine the register data with the existing
+        # attribute value to get the new attribute value.
+        self._complex_modify_attr = {
+                49: ('test_burst_length', lambda val,data:(val//256)*256+data),
+                50: ('test_burst_length', lambda val,data:(val%256)+data*256),
+                60: ('reset_cycles', lambda val,data:(val//256)*256+data),
+                61: ('reset_cycles',
+                    lambda val,data:(val//0x10000)*0x10000+data*256+val%256),
+                62: ('reset_cycles', lambda val,data:(val%0x10000)+data*0x10000)
+                }
+        # These registers store 32 bits over 4 registers each, and those
+        # 32 bits correspond to entries in a 32-entry list.
+        complex_array_spec = [
+                (range(34, 38), 'csa_bypass_select'),
+                (range(38, 42), 'csa_monitor_select'),
+                (range(42, 46), 'csa_testpulse_enable'),
+                (range(52, 56), 'channel_mask'),
+                (range(56, 60), 'external_trigger_mask')]
+        self._complex_array = {}
+        for addresses, label in complex_array_spec:
+            for i, address in enumerate(addresses):
+                complex_array[address] = (label, i)
+        # These registers each correspond to an entry in an array
+        self._trim_registers = list(range(32))
 
     def __str__(self):
         '''
@@ -606,7 +654,28 @@ class Configuration(object):
         value) pairs.
 
         '''
+        def bits_to_array(data):
+            bits = Bits('uint:8=%d' % data)
+            return [int(bit) for bit in bits][::-1]
 
+        for address, value in d.items():
+            if address in self._simple_registers:
+                setattr(self, self._simple_registers[address], value)
+            elif address in self._complex_modify_data:
+                name, extract = self._complex_modify_data[address]
+                setattr(self, name, extract(value))
+            elif address in self._complex_modify_attr:
+                name, combine = self._complex_modify_attr[address]
+                current_value = getattr(self, name)
+                setattr(self, name, combine(current_value, value))
+            elif address in self._complex_array:
+                name, index = self._complex_array[address]
+                affected = slice(index*8, (index+1)*8)
+                attr_list = getattr(self, name)
+                attr_list[affected] = bits_to_array(value)
+            elif address in self._trim_registers:
+                self.pixel_trim_thresholds[address] = value
+        return  #phew
 
     def write(self, filename, force=False, append=False):
         if os.path.isfile(filename):

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -113,6 +113,25 @@ class Configuration(object):
     channel_mask_addresses = list(range(52, 56))
     external_trigger_mask_addresses = list(range(56, 60))
     reset_cycles_addresses = [60, 61, 62]
+    register_names = ['pixel_trim_thresholds',
+                           'global_threshold',
+                           'csa_gain',
+                           'csa_bypass',
+                           'internal_bypass',
+                           'csa_bypass_select',
+                           'csa_monitor_select',
+                           'csa_testpulse_enable',
+                           'csa_testpulse_dac_amplitude',
+                           'test_mode',
+                           'cross_trigger_mode',
+                           'periodic_reset',
+                           'fifo_diagnostic',
+                           'sample_cycles',
+                           'test_burst_length',
+                           'adc_burst_length',
+                           'channel_mask',
+                           'external_trigger_mask',
+                           'reset_cycles']
 
     TEST_OFF = 0x0
     TEST_UART = 0x1
@@ -122,26 +141,7 @@ class Configuration(object):
         self.load('default.json')
 
         # Annoying things we have to do because the configuration
-        # register follows complex semantics
-        self.register_names = ['pixel_trim_thresholds',
-                               'global_threshold',
-                               'csa_gain',
-                               'csa_bypass',
-                               'internal_bypass',
-                               'csa_bypass_select',
-                               'csa_monitor_select',
-                               'csa_testpulse_enable',
-                               'csa_testpulse_dac_amplitude',
-                               'test_mode',
-                               'cross_trigger_mode',
-                               'periodic_reset',
-                               'fifo_diagnostic',
-                               'sample_cycles',
-                               'test_burst_length',
-                               'adc_burst_length',
-                               'channel_mask',
-                               'external_trigger_mask',
-                               'reset_cycles']
+        # register follows complex semantics:
         # The following dicts/lists specify how to translate a register
         # address into a sensible update to the Configuration object.
         # Simple registers are just the value stored in the register.

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -57,6 +57,21 @@ class Chip(object):
             packet.assign_parity()
         return packets
 
+    def sync_configuration(self):
+        '''
+        Adjust self.config to match whatever config read packets are in
+        self.reads.
+
+        Later packets in the list will overwrite earlier packets.
+
+        '''
+        updates = {}
+        for packet in self.reads:
+            if packet.packet_type == Packet.CONFIG_READ_PACKET:
+                updates[packet.register_address] = packet.register_data
+
+        self.config.from_dict(updates)
+
     def export_reads(self, only_new_reads=True):
         '''
         Return a dict of the packets this Chip has received.
@@ -584,6 +599,14 @@ class Configuration(object):
         for register_name in self.register_names:
             if register_name in d:
                 setattr(self, register_name, d[register_name])
+
+    def from_dict_registers(self, d):
+        '''
+        Load in the configuration specified by a dict of (register,
+        value) pairs.
+
+        '''
+
 
     def write(self, filename, force=False, append=False):
         if os.path.isfile(filename):

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -156,11 +156,11 @@ class Configuration(object):
         self._complex_modify_data = {
                 33: [('csa_gain', lambda data:data % 2),
                      ('csa_bypass', lambda data:(data//2) % 2),
-                     ('internal_bypass', lambda data:(data//8) % 2)]
+                     ('internal_bypass', lambda data:(data//8) % 2)],
                 47: [('test_mode', lambda data:data % 4),
                      ('cross_trigger_mode', lambda data:(data//4) % 2),
                      ('periodic_reset', lambda data:(data//8) % 2),
-                     ('fifo_diagnostic', lambda data(data//16) % 2)]
+                     ('fifo_diagnostic', lambda data:(data//16) % 2)]
                 }
         # These registers combine the register data with the existing
         # attribute value to get the new attribute value.
@@ -183,7 +183,7 @@ class Configuration(object):
         self._complex_array = {}
         for addresses, label in complex_array_spec:
             for i, address in enumerate(addresses):
-                complex_array[address] = (label, i)
+                self._complex_array[address] = (label, i)
         # These registers each correspond to an entry in an array
         self._trim_registers = list(range(32))
 
@@ -662,8 +662,9 @@ class Configuration(object):
             if address in self._simple_registers:
                 setattr(self, self._simple_registers[address], value)
             elif address in self._complex_modify_data:
-                name, extract = self._complex_modify_data[address]
-                setattr(self, name, extract(value))
+                attributes = self._complex_modify_data[address]
+                for name, extract in attributes:
+                    setattr(self, name, extract(value))
             elif address in self._complex_modify_attr:
                 name, combine = self._complex_modify_attr[address]
                 current_value = getattr(self, name)

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -70,7 +70,7 @@ class Chip(object):
             if packet.packet_type == Packet.CONFIG_READ_PACKET:
                 updates[packet.register_address] = packet.register_data
 
-        self.config.from_dict(updates)
+        self.config.from_dict_registers(updates)
 
     def export_reads(self, only_new_reads=True):
         '''

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -108,6 +108,16 @@ def test_chip_get_configuration_packets():
     assert packet.register_address == 40
     assert packet.register_data == 0
 
+def test_chip_sync_configuration():
+    chip = Chip(1, 0)
+    packet_type = Packet.CONFIG_READ_PACKET
+    packets = chip.get_configuration_packets(packet_type)
+    chip.reads = packets
+    chip.sync_configuration()
+    result = chip.config.all_data()
+    expected = [BitArray([0]*8)] * Configuration.num_registers
+    assert result == expected
+
 def test_chip_export_reads():
     chip = Chip(1, 2)
     packet = Packet()

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -1228,6 +1228,186 @@ def test_configuration_read_local():
     os.remove(abspath)
     assert result == expected
 
+def test_configuration_from_dict_reg_pixel_trim():
+    c = Configuration()
+    register_dict = { 0: 5, 15: 100 }
+    c.from_dict_registers(register_dict)
+    result_1 = c.pixel_trim_thresholds[0]
+    expected_1 = register_dict[0]
+    assert result_1 == expected_1
+    result_2 = c.pixel_trim_thresholds[15]
+    expected_2 = register_dict[15]
+    assert result_2 == expected_2
+
+def test_configuration_from_dict_reg_global_threshold():
+    c = Configuration()
+    register_dict = { 32: 182 }
+    c.from_dict_registers(register_dict)
+    result = c.global_threshold
+    expected = register_dict[32]
+    assert result == expected
+
+def test_configuration_from_dict_reg_csa_gain():
+    c = Configuration()
+    register_dict = { 33: 0 }
+    c.from_dict_registers(register_dict)
+    result = c.csa_gain
+    expected = 0
+    assert result == expected
+
+def test_configuration_from_dict_reg_csa_bypass():
+    c = Configuration()
+    register_dict = { 33: 2 }
+    c.from_dict_registers(register_dict)
+    result = c.csa_bypass
+    expected = 1
+    assert result == expected
+
+def test_configuration_from_dict_reg_internal_bypass():
+    c = Configuration()
+    register_dict = { 33: 8 }
+    c.from_dict_registers(register_dict)
+    result = c.internal_bypass
+    expected = 1
+    assert result == expected
+
+def test_configuration_from_dict_reg_csa_bypass_select():
+    c = Configuration()
+    register_dict = { 34: 0x12, 35: 0x34, 36: 0x56, 37: 0x78 }
+    c.from_dict_registers(register_dict)
+    result = c.csa_bypass_select
+    expected = [
+            0, 1, 0, 0, 1, 0, 0, 0,
+            0, 0, 1, 0, 1, 1, 0, 0,
+            0, 1, 1, 0, 1, 0, 1, 0,
+            0, 0, 0, 1, 1, 1, 1, 0
+            ]
+    assert result == expected
+
+def test_configuration_from_dict_reg_csa_monitor_select():
+    c = Configuration()
+    register_dict = { 38: 0x12, 39: 0x34, 40: 0x56, 41: 0x78 }
+    c.from_dict_registers(register_dict)
+    result = c.csa_monitor_select
+    expected = [
+            0, 1, 0, 0, 1, 0, 0, 0,
+            0, 0, 1, 0, 1, 1, 0, 0,
+            0, 1, 1, 0, 1, 0, 1, 0,
+            0, 0, 0, 1, 1, 1, 1, 0
+            ]
+    assert result == expected
+
+def test_configuration_from_dict_reg_csa_testpulse_enable():
+    c = Configuration()
+    register_dict = { 42: 0x12, 43: 0x34, 44: 0x56, 45: 0x78 }
+    c.from_dict_registers(register_dict)
+    result = c.csa_testpulse_enable
+    expected = [
+            0, 1, 0, 0, 1, 0, 0, 0,
+            0, 0, 1, 0, 1, 1, 0, 0,
+            0, 1, 1, 0, 1, 0, 1, 0,
+            0, 0, 0, 1, 1, 1, 1, 0
+            ]
+    assert result == expected
+
+def test_configuration_from_dict_reg_csa_testpulse_dac_amplitude():
+    c = Configuration()
+    register_dict = { 46: 193 }
+    c.from_dict_registers(register_dict)
+    result = c.csa_testpulse_dac_amplitude
+    expected = 193
+    assert result == expected
+
+def test_configuration_from_dict_reg_test_mode():
+    c = Configuration()
+    register_dict = { 47: 2 }
+    c.from_dict_registers(register_dict)
+    result = c.test_mode
+    expected = 2
+    assert result == expected
+
+def test_configuration_from_dict_reg_cross_trigger_mode():
+    c = Configuration()
+    register_dict = { 47: 4 }
+    c.from_dict_registers(register_dict)
+    result = c.cross_trigger_mode
+    expected = 1
+    assert result == expected
+
+def test_configuration_from_dict_reg_periodic_reset():
+    c = Configuration()
+    register_dict = { 47: 8 }
+    c.from_dict_registers(register_dict)
+    result = c.periodic_reset
+    expected = 1
+    assert result == expected
+
+def test_configuration_from_dict_reg_fifo_diagnostic():
+    c = Configuration()
+    register_dict = { 47: 16 }
+    c.from_dict_registers(register_dict)
+    result = c.fifo_diagnostic
+    expected = 1
+    assert result == expected
+
+def test_configuration_from_dict_reg_sample_cycles():
+    c = Configuration()
+    register_dict = { 48: 111 }
+    c.from_dict_registers(register_dict)
+    result = c.sample_cycles
+    expected = 111
+    assert result == expected
+
+def test_configuration_from_dict_reg_test_burst_length():
+    c = Configuration()
+    register_dict = { 49: 5, 50: 2}
+    c.from_dict_registers(register_dict)
+    result = c.test_burst_length
+    expected = 517  # = 256 * 2 + 1 * 5
+    assert result == expected
+
+def test_configuration_from_dict_reg_adc_burst_length():
+    c = Configuration()
+    register_dict = { 51: 83 }
+    c.from_dict_registers(register_dict)
+    result = c.adc_burst_length
+    expected = 83
+    assert result == expected
+
+def test_configuration_from_dict_reg_channel_mask():
+    c = Configuration()
+    register_dict = { 52: 0x12, 53: 0x34, 54: 0x56, 55: 0x78 }
+    c.from_dict_registers(register_dict)
+    result = c.channel_mask
+    expected = [
+            0, 1, 0, 0, 1, 0, 0, 0,
+            0, 0, 1, 0, 1, 1, 0, 0,
+            0, 1, 1, 0, 1, 0, 1, 0,
+            0, 0, 0, 1, 1, 1, 1, 0
+            ]
+    assert result == expected
+
+def test_configuration_from_dict_reg_external_trigger_mask():
+    c = Configuration()
+    register_dict = { 56: 0x12, 57: 0x34, 58: 0x56, 59: 0x78 }
+    c.from_dict_registers(register_dict)
+    result = c.external_trigger_mask
+    expected = [
+            0, 1, 0, 0, 1, 0, 0, 0,
+            0, 0, 1, 0, 1, 1, 0, 0,
+            0, 1, 1, 0, 1, 0, 1, 0,
+            0, 0, 0, 1, 1, 1, 1, 0
+            ]
+    assert result == expected
+
+def test_configuration_from_dict_reg_reset_cycles():
+    c = Configuration()
+    register_dict = { 60: 0x12, 61: 0x34, 62: 0x56 }
+    c.from_dict_registers(register_dict)
+    result = c.reset_cycles
+    expected = 0x563412
+    assert result == expected
+
 def test_controller_init_chips():
     controller = Controller(None)
     controller.init_chips()


### PR DESCRIPTION
The `chip.sync_configuration` method goes through `chip.reads` in chronological order and finds all of the configurations that have been read out. The most recent read is saved for each configuration register. Then the values from those configuration registers are used to update the attributes of `chip.config`.

Assisting in this effort is a set of private attributes of the Configuration object, which specify how to update the appropriate attributes given a particular register number and the data stored in that register.