### PR TITLE
PacketCollections: the solution to read history and to controller.reads

### DIFF
--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -1134,6 +1134,20 @@ class PacketCollection(object):
         self.packets = packets
         self.bytestream = bytestream
 
+    def __repr__(self):
+        return '<%s with %d packets>' % (self.__class__.__name__,
+                len(self.packets))
+
+    def __str__(self):
+        if len(self.packets) < 20:
+            return '\n'.join(str(packet) for packet in self.packets)
+        else:
+            beginning = '\n'.join(str(packet) for packet in self.packets[:10])
+            middle = '\n'.join(['   .', '   . omitted %d packets' %
+                (len(self.packets)-20), '   .'])
+            end = '\n'.join(str(packet) for packet in self.packets[-10:])
+            return '\n'.join([beginning, middle, end])
+
     def show_reads(self, start=0, stop=None, step=1):
         if stop is None:
             stop = len(self.packets)

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -895,14 +895,15 @@ class Controller(object):
         bytestreams.append(current_bytestream)
         return bytestreams
 
-    def save_output(self, filename):
+    def save_output(self, filename, message):
         '''Save the data read by each chip to the specified file.'''
         data = {}
-        data['chips'] = list(map(lambda x:x.export_reads(), self.chips))
+        data['reads'] = [collection.to_dict() for collection in self.reads]
+        data['chips'] = [repr(chip) for chip in self.chips]
+        data['message'] = message
         with open(filename, 'w') as outfile:
             json.dump(data, outfile, indent=4,
                     separators=(',',':'), sort_keys=True)
-
 
 
 class Packet(object):
@@ -1237,6 +1238,20 @@ class PacketCollection(object):
         else:
             return ' '.join(self.packets[key].bits.bin[i:i+8] for i in
                     range(0, Packet.size, 8))
+
+    def to_dict(self):
+        '''
+        Export the information in this PacketCollection to a dict.
+
+        '''
+        d = {}
+        d['packets'] = [packet.export() for packet in self.packets]
+        d['id'] = id(self)
+        d['parent'] = 'None' if self.parent is None else id(self.parent)
+        d['message'] = self.message
+        d['read_id'] = self.read_id
+        d['bytestream'] = str(self.bytestream)
+        return d
 
     def origin(self):
         '''

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -818,15 +818,18 @@ class Controller(object):
         bytestreams = self.format_bytestream(formatted_packets)
         return bytestreams
 
-    def run(self, timelimit):
+    def run(self, timelimit, message):
         data = self.serial_read(timelimit)
         packets = self.parse_input(data)
-        new_packets = PacketCollection(packets, data)
+        new_packets = PacketCollection(packets, data, message)
         self.packets.append(new_packets)
         by_chipid = new_packets.by_chipid()
         for chip in self.chips:
             if chip.chip_id in by_chipid:
-                chip.reads.append(PacketCollection(by_chipid[chip.chip_id]))
+                message = new_packets.message + ' | chip %d' % chip.chipid
+                chip_packets = PacketCollection(by_chipid[chip.chip_id],
+                        message=message)
+                chip.reads.append(chip_packets)
 
     def run_testpulse(self, list_of_channels):
         return

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -1165,6 +1165,7 @@ class PacketCollection(object):
         self.packets = packets
         self.bytestream = bytestream
         self.message = message
+        self.parent = None
 
     def __eq__(self, other):
         '''
@@ -1216,6 +1217,7 @@ class PacketCollection(object):
         if isinstance(key, slice):
             items = PacketCollection([p for p in self.packets[key]])
             items.message = '%s | subset %s' % (self.message, key)
+            items.parent = self
             return items
         elif isinstance(key, tuple):
             if key[1] == 'bits':

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -1147,6 +1147,15 @@ class PacketCollection(object):
         self.bytestream = bytestream
         self.message = message
 
+    def __eq__(self, other):
+        '''
+        Return True if the packets, message and bytestream compare equal.
+
+        '''
+        return (self.packets == other.packets and
+                self.message == other.message and
+                self.bytestream == other.bytestream)
+
     def __repr__(self):
         return '<%s with %d packets>' % (self.__class__.__name__,
                 len(self.packets))

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -1165,6 +1165,7 @@ class PacketCollection(object):
         self.packets = packets
         self.bytestream = bytestream
         self.message = message
+        self.read_id = read_id
         self.parent = None
 
     def __eq__(self, other):

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -1240,7 +1240,7 @@ class PacketCollection(object):
         '''
         return [packet for packet in self.packets if packet.chipid == chipid]
 
-    def by_chipid(self, chipid):
+    def by_chipid(self):
         '''
         Return a dict of { chipid: [packet] }.
 

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -1533,10 +1533,8 @@ def test_controller_write_configuration_write_read(capfd):
     controller.chips.append(chip)
     to_read = b's\x08\x0034567\x00q'
     MockSerialPort.data_to_mock_read = to_read
-    unprocessed = controller.write_configuration(chip, registers=5, write_read=0.1)
-    assert unprocessed == b''
-    result = chip.reads[0].bytes()
-    assert result == to_read[1:-2]
+    result = controller.write_configuration(chip, registers=5, write_read=0.1)
+    assert result[0].bytes() == to_read[1:-2]
     conf_data = chip.get_configuration_packets(Packet.CONFIG_WRITE_PACKET)[5]
     expected = bytes2str(controller.format_UART(chip, conf_data))
     result, err = capfd.readouterr()
@@ -1549,10 +1547,7 @@ def test_controller_parse_input():
     packets = chip.get_configuration_packets(Packet.CONFIG_READ_PACKET)
     fpackets = [controller.format_UART(chip, p) for p in packets]
     bytestream = b''.join(controller.format_bytestream(fpackets))
-    remainder_bytes = controller.parse_input(bytestream)
-    expected_remainder_bytes = b''
-    assert remainder_bytes == expected_remainder_bytes
-    result = chip.reads
+    result = controller.parse_input(bytestream)
     expected = packets
     assert result == expected
 
@@ -1565,11 +1560,8 @@ def test_controller_parse_input_dropped_data_byte():
     fpackets = [controller.format_UART(chip, p) for p in packets]
     bytestream = b''.join(controller.format_bytestream(fpackets))
     # Drop a byte in the first packet
-    bytestream_faulty = bytestream[1:]
-    remainder_bytes = controller.parse_input(bytestream_faulty)
-    expected_remainder_bytes = b''
-    assert remainder_bytes == expected_remainder_bytes
-    result = chip.reads
+    bytestream_faulty = bytestream[:5] + bytestream[6:]
+    result = controller.parse_input(bytestream_faulty)
     expected = packets[1:]
     assert result == expected
 
@@ -1582,10 +1574,7 @@ def test_controller_parse_input_dropped_start_byte():
     bytestream = b''.join(controller.format_bytestream(fpackets))
     # Drop the first start byte
     bytestream_faulty = bytestream[1:]
-    remainder_bytes = controller.parse_input(bytestream_faulty)
-    expected_remainder_bytes = b''
-    assert remainder_bytes == expected_remainder_bytes
-    result = chip.reads
+    result = controller.parse_input(bytestream_faulty)
     expected = packets[1:]
     assert result == expected
 
@@ -1598,10 +1587,7 @@ def test_controller_parse_input_dropped_stop_byte():
     bytestream = b''.join(controller.format_bytestream(fpackets))
     # Drop the first stop byte
     bytestream_faulty = bytestream[:9] + bytestream[10:]
-    remainder_bytes = controller.parse_input(bytestream_faulty)
-    expected_remainder_bytes = b''
-    assert remainder_bytes == expected_remainder_bytes
-    result = chip.reads
+    result = controller.parse_input(bytestream_faulty)
     expected = packets[1:]
     assert result == expected
 
@@ -1614,10 +1600,7 @@ def test_controller_parse_input_dropped_stopstart_bytes():
     bytestream = b''.join(controller.format_bytestream(fpackets))
     # Drop the first stop byte
     bytestream_faulty = bytestream[:9] + bytestream[11:]
-    remainder_bytes = controller.parse_input(bytestream_faulty)
-    expected_remainder_bytes = b''
-    assert remainder_bytes == expected_remainder_bytes
-    result = chip.reads
+    result = controller.parse_input(bytestream_faulty)
     expected = packets[2:]
     assert result == expected
 

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -4,7 +4,8 @@ Use the pytest framework to write tests for the larpix module.
 '''
 from __future__ import print_function
 import pytest
-from larpix.larpix import Chip, Packet, Configuration, Controller
+from larpix.larpix import (Chip, Packet, Configuration, Controller,
+        PacketCollection)
 from bitstring import BitArray
 import json
 import os
@@ -1618,4 +1619,21 @@ def test_controller_parse_input_dropped_stopstart_bytes():
     assert remainder_bytes == expected_remainder_bytes
     result = chip.reads
     expected = packets[2:]
+    assert result == expected
+
+def test_packetcollection_show_reads():
+    packet = Packet()
+    packet.packet_type = Packet.TEST_PACKET
+    packet.test_counter = 12345
+    pc = PacketCollection([packet], packet.bytes())
+    result = pc.show_reads()
+    expected = [str(packet)]
+    assert result == expected
+
+def test_packetcollection_show_reads_bits():
+    packet = Packet()
+    pc = PacketCollection([packet], packet.bytes())
+    result = pc.show_reads_bits()
+    expected = ['00000000 00000000 00000000 00000000 00000000 00000000'
+            ' 000000']
     assert result == expected

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -1614,3 +1614,14 @@ def test_packetcollection_getitem_slice_bits():
     expected = [' '.join(p.bits.bin[i:i+8] for i in range(0,
         Packet.size, 8)) for p in packets[:10]]
     assert result == expected
+
+def test_packetcollection_origin():
+    chip = Chip(0, 0)
+    packets = chip.get_configuration_packets(Packet.CONFIG_WRITE_PACKET)
+    collection = PacketCollection(packets, message='hello')
+    first_gen = collection.by_chipid()[0]
+    second_gen = first_gen.by_chipid()[0]
+    assert first_gen.parent is collection
+    assert first_gen.origin() is collection
+    assert second_gen.parent is first_gen
+    assert second_gen.origin() is collection

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -173,12 +173,25 @@ def test_controller_save_output(tmpdir):
     p = Packet()
     chip.reads.append(p)
     controller.chips.append(chip)
+    collection = PacketCollection([p], p.bytes(), 'hi', 0)
+    controller.reads.append(collection)
     name = str(tmpdir.join('test.json'))
-    controller.save_output(name)
+    controller.save_output(name, 'this is a test')
     with open(name) as f:
         result = json.load(f)
     expected = {
-            'chips': [chip.export_reads(only_new_reads=False)]
+            'chips': [repr(chip)],
+            'message': 'this is a test',
+            'reads': [
+                {
+                    'packets': [p.export()],
+                    'id': id(collection),
+                    'parent': 'None',
+                    'message': 'hi',
+                    'read_id': 0,
+                    'bytestream': str(p.bytes())
+                    }
+                ]
             }
     assert result == expected
 

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -1486,8 +1486,7 @@ def test_controller_write_configuration(capfd):
     controller._test_mode = True
     controller._serial = MockSerialPort
     chip = Chip(2, 4)
-    result = controller.write_configuration(chip)
-    assert result == b''
+    controller.write_configuration(chip)
     conf_data = chip.get_configuration_packets(Packet.CONFIG_WRITE_PACKET)
     expected = ' '.join(map(bytes2str, [controller.format_UART(chip, conf_data_i) for
             conf_data_i in conf_data]))
@@ -1499,8 +1498,7 @@ def test_controller_write_configuration_one_reg(capfd):
     controller._test_mode = True
     controller._serial = MockSerialPort
     chip = Chip(2, 4)
-    result = controller.write_configuration(chip, 0)
-    assert result == b''
+    controller.write_configuration(chip, 0)
     conf_data = chip.get_configuration_packets(Packet.CONFIG_WRITE_PACKET)[0]
     expected = bytes2str(controller.format_UART(chip, conf_data))
     result, err = capfd.readouterr()
@@ -1514,8 +1512,9 @@ def test_controller_write_configuration_write_read(capfd):
     controller.chips.append(chip)
     to_read = b's\x08\x0034567\x00q'
     MockSerialPort.data_to_mock_read = to_read
-    result = controller.write_configuration(chip, registers=5, write_read=0.1)
-    assert result[0].bytes() == to_read[1:-2]
+    controller.write_configuration(chip, registers=5, write_read=0.1)
+    assert chip.reads[0][0].bytes() == to_read[1:-2]
+    assert controller.reads[0].bytestream == to_read
     conf_data = chip.get_configuration_packets(Packet.CONFIG_WRITE_PACKET)[5]
     expected = bytes2str(controller.format_UART(chip, conf_data))
     result, err = capfd.readouterr()


### PR DESCRIPTION
Inspired by #34, I wrote a class to manage groups of packets, called `PacketCollection`. The idea is that each call to `controller.run` would create a PacketCollection with the packets that were read in during the run.

Please take a look ( @peter-madigan @dadwyer ) and comment if you'd like. I'm still working on it. This isn't (yet) a request to merge. But probably will be in a day or 2.

PacketCollections have a bunch of responsibilities and functionalities, including

 - [X] sorting packets by chip ID (`with_chipid` for a single chip and `by_chipid` for a dict of all chips)
 - [X] storing the raw bytestream received from the FPGA
 - [X] storing a log message describing the packets
 - [X] displaying the packets in the collection in a reasonable way (`__str__`)
 - [x] grouping packets in data files on disk
 - [x] tracking the order of reads (via Peter's `read_id` idea)
 - [x] tracking their own ancestries back to the original PacketCollection created during `controller.run`. Related is adding a "lookup index" to Packets to facilitate a connection between the Packet object and the original bytestream. (Eg. browsing previous or next packets, or checking to see if something garbled happened right before or right after a Packet was received.)

I have not yet decided how to handle the following:

 - timestamps: it is trivial to save the CPU timestamp at the start and/or end of a read, but that does not help us with the time of individual packet arrivals. To get this working the right way, we might have to handle #53 (sending commands during a serial read).
 - splitting up the bytestream, if at all, when creating "subset" PacketCollections. The obvious use case for this would be when dividing up packets per chip. On the other hand, the only reason we'd want to save the entire received bytestream is if we wanted to examine a segment that couldn't be parsed. All of the valid parts of the bytestream are converted to Packets.

cc: #44 #29 