### PR TITLE
Basic LArPix simulation

### DIFF
--- a/larpix/simulation.py
+++ b/larpix/simulation.py
@@ -169,9 +169,7 @@ class MockSerial(object):
         self.formatter.receive_mosi(data)
 
     def read(self, nbytes):
-        if self.timeout is None:
-            pass
-        elif self.timeout > 0:
+        if self.timeout:
             start_time = time.time()
             stop_time = start_time + self.timeout
             while time.time() < stop_time:
@@ -207,7 +205,8 @@ class MockFormatter(object):
         trigger.
 
         '''
-        self.mosi_destination.maybe_trigger()
+        if self.mosi_destination:
+            self.mosi_destination.maybe_trigger()
 
     def receive_mosi(self, data):
         '''

--- a/larpix/simulation.py
+++ b/larpix/simulation.py
@@ -87,7 +87,7 @@ class MockLArPix(object):
         Return a timestamp for this chip that makes sense.
 
         '''
-        return int(time.time()//100)
+        return int(time.time()*1e6 % 1000000)
 
     def digitize(self, voltage):
         '''

--- a/larpix/simulation.py
+++ b/larpix/simulation.py
@@ -8,6 +8,31 @@ import larpix.larpix as larpix
 import time
 from collections import deque
 
+def model(chips):
+    '''
+    Return a MockSerial object to communicate with the given daisy chain
+    of chips.
+
+    To install this model, set ``controller._serial = model(...)``. Then
+    just run the code normally.
+
+    '''
+    serial = MockSerial()
+    formatter = MockFormatter()
+    serial.formatter = formatter
+    mock_chips = []
+    for chip in chips:
+        mock_chips.append(MockLArPix(chip.chip_id, chip.io_chain))
+    mock_chips[0].previous = formatter
+    formatter.mosi_destination = mock_chips[0]
+    mock_chips[-1].next = formatter
+    formatter.miso_source = mock_chips[-1]
+    for i, mock in enumerate(mock_chips[1:]):
+        mock.previous = mock_chips[i]
+    for i, mock in enumerate(mock_chips[:-1]):
+        mock.next = mock_chips[i+1]
+    return serial
+
 class MockLArPix(object):
     '''
     A mock/simulation LArPix chip that can interface with the

--- a/larpix/simulation.py
+++ b/larpix/simulation.py
@@ -1,0 +1,99 @@
+'''
+Simulate the LArPix chip's behavior.
+
+'''
+from __future__ import absolute_import
+
+import larpix.larpix as larpix
+import time
+
+class MockLArPix(object):
+    '''
+    A mock/simulation LArPix chip that can interface with the
+    ``larpix.larpix`` module.
+
+    '''
+    def __init__(self, chip_id, io_chain):
+        self.chip_id = chip_id
+        self.io_chain = io_chain
+        self.previous = None
+        self.next = None
+        self.config = larpix.Configuration()
+        self.vref = 1.5
+        self.vcm = 0.2
+        self.adc_bins = 256
+        self.adc_lsb = (self.vref - self.vcm)/self.adc_bins
+
+    def receive(self, packet):
+        '''
+        Handle the packet by either processing it or sending it on.
+
+        '''
+        if packet.chipid != self.chip_id:
+            return self.send(packet)
+        if packet.packet_type == packet.CONFIG_READ_PACKET:
+            output = larpix.Packet()
+            output.packet_type = packet.CONFIG_READ_PACKET
+            output.chipid = self.chip_id
+            output.register_address = packet.register_address
+            output.register_data = self.config.all_data()[
+                    packet.register_address]
+            output.assign_parity()
+            return self.send(output)
+        elif packet.packet_type == packet.CONFIG_WRITE_PACKET:
+            update = {packet.register_address: packet.register_data}
+            self.config.from_dict_registers(update)
+            return None
+        else:
+            return self.send(packet)
+
+    def send(self, packet):
+        '''
+        Emit and return the given packet.
+
+        '''
+        if self.next is None:
+            print(repr(packet))
+            return packet
+        else:
+            return self.next.receive(packet)
+
+    def trigger(self, n_electrons, channel):
+        '''
+        Trigger the chip for charge readout.
+
+        '''
+        if self.config.csa_gain == 0:
+            gain_uV_e = 45
+        elif self.config.csa_gain == 1:
+            gain_uV_e = 4
+        V_per_uV = 1e-6
+        voltage = n_electrons * gain_uV_e * V_per_uV
+        adcs = self.digitize(voltage)
+        packet = larpix.Packet()
+        packet.packet_type = packet.DATA_PACKET
+        packet.chipid = self.chip_id
+        packet.channel_id = channel
+        packet.timestamp = self.timestamp()
+        packet.dataword = adcs
+        packet.assign_parity()
+        return self.send(packet)
+
+    def timestamp(self):
+        '''
+        Return a timestamp for this chip that makes sense.
+
+        '''
+        return int(time.time()//100)
+
+    def digitize(self, voltage):
+        '''
+        Convert the given voltage into ADC counts.
+
+        '''
+        numerator = (voltage - self.vcm) * self.adc_bins
+        denominator = self.vref - self.vcm
+        ratio = int(numerator//denominator)
+        ratio = max(0, ratio)
+        ratio = min(self.adc_bins-1, ratio)
+        return ratio

--- a/larpix/simulation.py
+++ b/larpix/simulation.py
@@ -57,6 +57,8 @@ class MockLArPix(object):
             receive_fn = self.next.receive
         elif isinstance(self.next, MockFormatter):
             receive_fn = self.next.receive_miso
+        elif self.next is None:
+            receive_fn = lambda x:{'sent': packet}
         return receive_fn(packet)
 
     def trigger(self, n_electrons, channel):

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -72,6 +72,40 @@ def test_MockLArPix_send_to_formatter():
     expected = packet
     assert result == expected
 
+def test_MockLArPix_timestamp():
+    chip = MockLArPix(0, 0)
+    timestamp1 = chip.timestamp()
+    timestamp2 = chip.timestamp()
+    rollover = timestamp2 < timestamp1
+    if rollover:
+        assert timestamp1 - timestamp2 > 9e5
+    else:
+        assert True
+
+def test_MockLArPix_digitize():
+    chip = MockLArPix(0, 0)
+    result = chip.digitize(chip.vcm)
+    expected = 0
+    assert result == expected
+    result = chip.digitize(chip.vref)
+    expected = 255
+    assert result == expected
+    result = chip.digitize(chip.vcm + (chip.vref - chip.vcm)/2)
+    expected = 128
+    assert result == expected
+
+def test_MockLArPix_trigger():
+    chip = MockLArPix(1, 0)
+    result = chip.trigger(1e5, 3)
+    expected_packet = Packet()
+    expected_packet.chipid = 1
+    expected_packet.channel_id = 3
+    expected_packet.dataword = 39  # computed by hand
+    expected_packet.timestamp = result['sent'].timestamp  # have to cheat
+    expected_packet.assign_parity()
+    expected = {'sent': expected_packet}
+    assert result == expected
+
 def test_MockSerial_write():
     serial = MockSerial()
     formatter = MockFormatter()

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -1,0 +1,154 @@
+'''
+Use the pytest framework to write tests for the simulation module.
+
+This is not quite unit testing because all of the methods are highly
+coupled. So I'm doing the best I can to make sure all the functionality
+is tested.
+
+'''
+from __future__ import print_function
+import pytest
+from collections import deque
+from larpix.larpix import (Packet)
+from larpix.simulation import (MockLArPix, MockSerial, MockFormatter)
+
+def test_MockLArPix_receive_not_mine():
+    formatter = MockFormatter()
+    chip = MockLArPix(1, 0)
+    nextchip = MockLArPix(2, 0)
+    formatter.mosi_destination = chip
+    chip.next = nextchip
+    nextchip.next = formatter
+    formatter.miso_source = nextchip
+    packet = Packet()
+    packet.chipid = 100
+    packet.assign_parity()
+    result = chip.receive(packet)
+    expected = packet
+    assert result == expected
+
+def test_MockLArPix_receive_config_read():
+    formatter = MockFormatter()
+    chip = MockLArPix(1, 0)
+    chip.next = formatter
+    packet = Packet()
+    packet.chipid = 1
+    packet.packet_type = Packet.CONFIG_READ_PACKET
+    packet.assign_parity()
+    result = chip.receive(packet)
+    expected = Packet()
+    expected.chipid = 1
+    expected.packet_type = Packet.CONFIG_READ_PACKET
+    expected.register_data = chip.config.pixel_trim_thresholds[0]
+    expected.assign_parity()
+    assert result == expected
+
+def test_MockLArPix_receive_config_write():
+    chip = MockLArPix(1, 0)
+    packet = Packet()
+    packet.chipid = 1
+    packet.packet_type = Packet.CONFIG_WRITE_PACKET
+    packet.register_data = 3
+    packet.assign_parity()
+    result = chip.receive(packet)
+    expected = None
+    assert result == expected
+    result_config = chip.config.pixel_trim_thresholds[0]
+    expected_config = 3
+    assert result == expected
+
+def test_MockSerial_write():
+    serial = MockSerial()
+    formatter = MockFormatter()
+    serial.formatter = formatter
+    chip = MockLArPix(0, 0)
+    formatter.mosi_destination = chip
+    chip.previous = formatter
+    chip.next = formatter
+    formatter.miso_source = chip
+    packet = Packet()
+    packet.assign_parity()
+    bytestream = b's' + packet.bytes() + b'\x00q'
+    serial.write(bytestream)
+    result = formatter.miso_buffer
+    expected = deque([packet])
+    assert result == expected
+
+def test_MockSerial_read_correct_nbytes():
+    serial = MockSerial()
+    formatter = MockFormatter()
+    serial.formatter = formatter
+    packet = Packet()
+    formatter.miso_buffer.append(packet)
+    result = serial.read(10)
+    expected = b's' + packet.bytes() + b'\x00q'
+    assert result == expected
+
+def test_MockSerial_read_fewer_nbytes():
+    serial = MockSerial()
+    formatter = MockFormatter()
+    serial.formatter = formatter
+    packet = Packet()
+    formatter.miso_buffer.append(packet)
+    result = serial.read(5)
+    expected = (b's' + packet.bytes() + b'\x00q')[:5]
+    assert result == expected
+
+def test_MockSerial_read_extra_nbytes():
+    serial = MockSerial()
+    formatter = MockFormatter()
+    serial.formatter = formatter
+    packet = Packet()
+    formatter.miso_buffer.append(packet)
+    result = serial.read(15)
+    expected = b's' + packet.bytes() + b'\x00q'
+    assert result == expected
+
+def test_MockFormatter_receive_mosi():
+    formatter = MockFormatter()
+    chip = MockLArPix(0, 0)
+    formatter.mosi_destination = chip
+    chip.next = formatter
+    packet = Packet()
+    packet.assign_parity()
+    bytestream = b's' + packet.bytes() + b'\x00q'
+    formatter.receive_mosi(bytestream)
+    result = formatter.miso_buffer
+    expected = deque([packet])
+    assert result == expected
+
+def test_MockFormatter_receive_miso():
+    formatter = MockFormatter()
+    packet = Packet()
+    formatter.receive_miso(packet)
+    result = formatter.miso_buffer
+    expected = deque([packet])
+    assert result == expected
+
+def test_MockFormatter_send_mosi():
+    formatter = MockFormatter()
+    chip = MockLArPix(0, 0)
+    formatter.mosi_destination = chip
+    chip.next = formatter
+    packet = Packet()
+    packet.assign_parity()
+    formatter.send_mosi([packet])
+    result = formatter.miso_buffer
+    expected = deque([packet])
+    assert result == expected
+
+def test_MockFormatter_send_miso_full_packet():
+    formatter = MockFormatter()
+    packet = Packet()
+    formatter.miso_buffer.append(packet)
+    result = formatter.send_miso(10)
+    expected = b's\x00\x00\x00\x00\x00\x00\x00\x00q'
+    assert result == expected
+
+def test_MockFormatter_send_miso_partial_packet():
+    formatter = MockFormatter()
+    packet = Packet()
+    formatter.miso_buffer.append(packet)
+    result = formatter.send_miso(5)
+    expected = b's\x00\x00\x00\x00'
+    assert result == expected


### PR DESCRIPTION
The new ``larpix.simulation`` module allows for easy simulations of the control software. It hooks right in to the existing software via the call ``controller._serial = simulation.model(chips)``. After that, configuration writes and reads work as expected, updating the mock chip's configuration registers and reading them out as packets to the controller.

The configuration registers don't actually do anything yet to affect the chip's behavior, except for the CSA gain, which was easy to program in to the trigger functionality. Right now, the only behavior for the chips is to trigger at random times on a random channel with a charge of 1e5 electrons. I'll need to do more work for that.

Even though the module is not complete, it is still worth testing out with new scripts to make sure the script's code runs smoothly.

Fixes #13 