### PR TITLE
Resolve some quick/easy issues

### DIFF
--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -773,13 +773,18 @@ class Controller(object):
                     data_in += stream
         return data_in
 
-    def write_configuration(self, chip, registers=None, write_read=0):
+    def write_configuration(self, chip, registers=None, write_read=0,
+            message=None):
         if registers is None:
             registers = list(range(Configuration.num_registers))
         elif isinstance(registers, int):
             registers = [registers]
         else:
             pass
+        if message is None:
+            message = 'configuration write'
+        else:
+            message = 'configuration write: ' + message
         bytestreams = self.get_configuration_bytestreams(chip,
                 Packet.CONFIG_WRITE_PACKET, registers)
         if write_read == 0:
@@ -788,7 +793,7 @@ class Controller(object):
             miso_bytestream = self.serial_write_read(bytestreams,
                     timelimit=write_read)
             packets = self.parse_input(miso_bytestream)
-            self.store_packets(packets, miso_bytestream, 'configuration write')
+            self.store_packets(packets, miso_bytestream, message)
 
     def read_configuration(self, chip, registers=None, timeout=1):
         if registers is None:
@@ -797,11 +802,15 @@ class Controller(object):
             registers = [registers]
         else:
             pass
+        if message is None:
+            message = 'configuration read'
+        else:
+            message = 'configuration read: ' + message
         bytestreams = self.get_configuration_bytestreams(chip,
                 Packet.CONFIG_READ_PACKET, registers)
         data = self.serial_write_read(bytestreams, timeout)
         packets = self.parse_input(data)
-        self.store_packets(packets, data, 'configuration read')
+        self.store_packets(packets, data, message)
 
     def get_configuration_bytestreams(self, chip, packet_type, registers):
         # The configuration must be sent one register at a time

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -805,11 +805,11 @@ class Controller(object):
 
     def get_configuration_bytestreams(self, chip, packet_type, registers):
         # The configuration must be sent one register at a time
-        configuration_packets = \
+        all_configuration_packets = \
             chip.get_configuration_packets(packet_type);
-        for i in range(len(configuration_packets)-1, -1, -1):
-            if i not in registers:
-                del configuration_packets[i]
+        configuration_packets = []
+        for register in registers:
+            configuration_packets.append(all_configuration_packets[register])
         formatted_packets = [self.format_UART(chip, p) for p in
                 configuration_packets]
         bytestreams = self.format_bytestream(formatted_packets)

--- a/larpix/tasks.py
+++ b/larpix/tasks.py
@@ -68,12 +68,16 @@ def get_chip_ids(**settings):
     chips = []
     for chip in controller.chips:
         controller.read_configuration(chip, 0, timeout=0.1)
-        if len(chip.reads)<1:
+        if len(chip.reads) == 0:
             print('Chip ID %d: Packet lost in black hole.  No connection?' %
                   chip.chip_id)
             continue
-        read_packet = chip.reads[-1]
-        if read_packet.register_data != 0:
+        if len(chip.reads[0] != 1):
+            print('Cannot determine if chip %d exists because more'
+                    'than 1 packet was received (expected 1)' %
+                    chip.chip_id)
+            continue
+        if read_packets[0].register_data != 0:
             chips.append(chip)
             logger.info('Found chip %s' % chip)
     controller.timeout = stored_timeout

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -1552,6 +1552,18 @@ def test_controller_write_configuration_write_read(capfd):
     result, err = capfd.readouterr()
     assert result == expected
 
+def test_controller_get_configuration_bytestreams():
+    controller = Controller(None)
+    chip = Chip(0, 0)
+    controller.chips.append(chip)
+    result = controller.get_configuration_bytestreams(chip,
+            Packet.CONFIG_WRITE_PACKET, [1, 0])
+    all_packets = chip.get_configuration_packets(Packet.CONFIG_WRITE_PACKET)
+    bytestream_reg_0 = controller.format_UART(chip, all_packets[0])
+    bytestream_reg_1 = controller.format_UART(chip, all_packets[1])
+    expected = [bytestream_reg_1 + bytestream_reg_0]
+    assert result == expected
+
 def test_controller_parse_input():
     controller = Controller(None)
     chip = Chip(2, 4)


### PR DESCRIPTION
Improve configuration_read and configuration_write by allowing a specific order of registers (#52), and allowing for a log message to be saved to the ``PacketCollection`` (#59)

Update ``larpix.tasks.get_chip_ids`` to handle ``PacketCollection``s (and also more gracefully handle problems involving too many or too few packets received) (#63)