### PR TITLE
Split up the idea of "active chips" from "all possible chips"

### DIFF
--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -710,11 +710,25 @@ class Controller(object):
     '''
     Controls a collection of LArPix Chip objects.
 
+    Properties and attributes:
+
+    - ``chips``: the ``Chip`` objects that the controller controls
+    - ``all_chip``: all possible ``Chip`` objects (considering there are
+      a finite number of chip IDs).
+    - ``port``: the path to the serial port, i.e. "/dev/(whatever)"
+    - ``timeout``: the timeout used for serial commands. This can be
+      changed between calls to the read and write commands.
+    - ``reads``: list of all the PacketCollections that have been sent
+      back to this controller. PacketCollections are created by
+      ``run``, ``write_configuration``, and ``read_configuration``, but
+      not by any of the ``serial_*`` methods.
+
     '''
     start_byte = b'\x73'
     stop_byte = b'\x71'
     def __init__(self, port='/dev/ttyUSB1'):
         self.chips = []
+        self.all_chips = self._init_chips()
         self.reads = []
         self.nreads = 0
         self.port = port
@@ -723,8 +737,12 @@ class Controller(object):
         self.max_write = 8192
         self._serial = serial.Serial
 
-    def init_chips(self, nchips = 256, iochain = 0):
-        self.chips = [Chip(i, iochain) for i in range(256)]
+    def _init_chips(self, nchips = 256, iochain = 0):
+        '''
+        Return all possible chips.
+
+        '''
+        return [Chip(i, iochain) for i in range(256)]
 
     def get_chip(self, chip_id, io_chain):
         for chip in self.chips:

--- a/larpix/tasks.py
+++ b/larpix/tasks.py
@@ -58,15 +58,13 @@ def get_chip_ids(**settings):
     logger.info('Executing get_chip_ids')
     if 'controller' in settings:
         controller = settings['controller']
-        if not controller.chips:
-            controller.init_chips()
     else:
         controller = larpix.Controller(settings['port'])
-        controller.init_chips()
+    controller.use_all_chips = True
     stored_timeout = controller.timeout
     controller.timeout=0.1
     chips = []
-    for chip in controller.chips:
+    for chip in controller.all_chips:
         controller.read_configuration(chip, 0, timeout=0.1)
         if len(chip.reads) == 0:
             print('Chip ID %d: Packet lost in black hole.  No connection?' %
@@ -81,6 +79,7 @@ def get_chip_ids(**settings):
             chips.append(chip)
             logger.info('Found chip %s' % chip)
     controller.timeout = stored_timeout
+    controller.use_all_chips = False
     return chips
 
 def simple_stats(**settings):

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -1471,6 +1471,13 @@ def test_controller_get_chip():
     controller.chips.append(chip)
     assert controller.get_chip(1, 3) == chip
 
+def test_controller_get_chip_all_chips():
+    controller = Controller(None)
+    controller.use_all_chips = True
+    result = controller.get_chip(5, 0)
+    expected = controller.all_chips[5]
+    assert result == expected
+
 def test_controller_get_chip_error():
     controller = Controller(None)
     chip = Chip(1, 3)

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -1461,9 +1461,8 @@ def test_configuration_from_dict_reg_reset_cycles():
 
 def test_controller_init_chips():
     controller = Controller(None)
-    controller.init_chips()
-    result = list(map(str, controller.chips))
-    expected = list(map(str, (Chip(i, 0) for i in range(256))))
+    result = list(map(repr, controller._init_chips()))
+    expected = list(map(repr, (Chip(i, 0) for i in range(256))))
     assert result == expected
 
 def test_controller_get_chip():


### PR DESCRIPTION
Controller objects now have controller.chips (to be populated manually) and controller.all_chips (initialized with object creation using what used to be controller.init_chips and is now controller._init_chips).

Fixes #48 