### PR TITLE
Update config.get_nondefault_registers to shorter output

### DIFF
--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -174,14 +174,14 @@ class Configuration(object):
                 }
         # These registers store 32 bits over 4 registers each, and those
         # 32 bits correspond to entries in a 32-entry list.
-        complex_array_spec = [
+        self._complex_array_spec = [
                 (range(34, 38), 'csa_bypass_select'),
                 (range(38, 42), 'csa_monitor_select'),
                 (range(42, 46), 'csa_testpulse_enable'),
                 (range(52, 56), 'channel_mask'),
                 (range(56, 60), 'external_trigger_mask')]
         self._complex_array = {}
-        for addresses, label in complex_array_spec:
+        for addresses, label in self._complex_array_spec:
             for i, address in enumerate(addresses):
                 self._complex_array[address] = (label, i)
         # These registers each correspond to an entry in an array
@@ -202,6 +202,19 @@ class Configuration(object):
         for register_name in self.register_names:
             if getattr(self, register_name) != getattr(default_config, register_name):
                 d[register_name] = getattr(self, register_name)
+        # Attempt to simplify some of the long values (array values)
+        for (name, value) in d.items():
+            if (name in (label for _, label in self._complex_array_spec)
+                    or name == 'pixel_trim_thresholds'):
+                different_values = []
+                for ch, (val, default_val) in enumerate(zip(value, getattr(
+                    default_config, name))):
+                    if val != default_val:
+                        different_values.append({'channel': ch, 'value': val})
+                if len(different_values) < 5:
+                    d[name] = different_values
+                else:
+                    pass
         return d
 
     @property

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -528,6 +528,27 @@ def test_configuration_get_nondefault_registers():
     expected['adc_burst_length'] = c.adc_burst_length
     assert c.get_nondefault_registers() == expected
 
+def test_configuration_get_nondefault_registers_array():
+    c = Configuration()
+    c.channel_mask[1] = 1
+    c.channel_mask[5] = 1
+    result = c.get_nondefault_registers()
+    expected = {
+            'channel_mask': [
+                { 'channel': 1, 'value': 1 },
+                { 'channel': 5, 'value': 1 }
+                ]
+            }
+    assert result == expected
+
+def test_configuration_get_nondefault_registers_many_changes():
+    c = Configuration()
+    c.channel_mask[:20] = [1]*20
+    result = c.get_nondefault_registers()
+    expected = { 'channel_mask': [1]*20 + [0]*12 }
+    assert result == expected
+
+
 def test_configuration_set_pixel_trim_thresholds():
     c = Configuration()
     expected = [0x05] * Chip.num_channels


### PR DESCRIPTION
In particular, if the output is an array with only a few (<5) changes,
just describe each changed array element rather than printing out the
entire array.

Fixes #50