### PR TITLE
Read and write configurations to/from multiple chips in one serial call

### DIFF
--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -854,6 +854,59 @@ class Controller(object):
         packets = self.parse_input(data)
         self.store_packets(packets, data, message)
 
+    def multi_write_configuration(self, chip_reg_pairs, write_read=0,
+            message=None):
+        '''
+        Send multiple write configuration commands at once.
+
+        ``chip_reg_pairs`` should be a list/iterable whose elements are
+        an valid arguments to ``Controller.write_configuration``,
+        excluding the ``write_read`` argument. Just like in the single
+        ``Controller.write_configuration``, setting ``write_read > 0`` will
+        have the controller read data during and after it writes, for
+        however many seconds are specified.
+
+        Examples:
+
+        These first 2 are equivalent and write the full configurations
+
+        >>> controller.multi_write_configuration([chip1, chip2, ...])
+        >>> controller.multi_write_configuration([(chip1, None), chip2, ...])
+
+        These 2 write the specified registers for the specified chips
+        in the specified order
+
+        >>> controller.multi_write_configuration([(chip1, 1), (chip2, 2), ...])
+        >>> controller.multi_write_configuration([(chip1, range(10)), chip2, ...])
+
+        '''
+        if message is None:
+            message = 'multi configuration write'
+        else:
+            message = 'multi configuration write: ' + message
+        final_bytestream = []
+        for chip_reg_pair in chip_reg_pairs:
+            if isinstance(chip_reg_pair, Chip):
+                chip_reg_pair = (chip_reg_pair, None)
+            chip, registers = chip_reg_pair
+            if registers is None:
+                registers = list(range(Configuration.num_registers))
+            elif isinstance(registers, int):
+                registers = [registers]
+            else:
+                pass
+            bytestreams = self.get_configuration_bytestreams(chip,
+                    Packet.CONFIG_WRITE_PACKET, registers)
+            final_bytestream += bytestreams
+        final_bytestream = self.format_bytestream(final_bytestream)
+        if write_read == 0:
+            self.serial_write(final_bytestream)
+        else:
+            miso_bytestream = self.serial_write_read(final_bytestream,
+                    timelimit=write_read)
+            packets = self.parse_input(miso_bytestream)
+            self.store_packets(packets, miso_bytestream, message)
+
     def get_configuration_bytestreams(self, chip, packet_type, registers):
         # The configuration must be sent one register at a time
         all_configuration_packets = \

--- a/larpix/tasks.py
+++ b/larpix/tasks.py
@@ -38,9 +38,7 @@ def startup(**settings):
     controller.use_all_chips = True
     for chip in controller.all_chips:
         chip.config.load("quiet.json")
-    for _ in range(nchips):
-        for chip in controller.all_chips:
-            controller.write_configuration(chip)
+    controller.multi_write_configuration(controller.all_chips)
     controller.use_all_chips = False
 
 def get_chip_ids(**settings):
@@ -61,8 +59,9 @@ def get_chip_ids(**settings):
     stored_timeout = controller.timeout
     controller.timeout=0.1
     chips = []
-    for chip in controller.all_chips:
-        controller.read_configuration(chip, 0, timeout=0.1)
+    chip_regs = [(c, 0) for c in controller.all_chips]
+    controller.multi_read_configuration(chip_regs, timeout=0.1)
+    for chip in controller.chips:
         if len(chip.reads) == 0:
             print('Chip ID %d: Packet lost in black hole.  No connection?' %
                   chip.chip_id)

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -1614,6 +1614,41 @@ def test_controller_multi_write_configuration_specify_registers(capfd):
     result, err = capfd.readouterr()
     assert result == expected
 
+
+def test_controller_multi_read_configuration(capfd):
+    controller = Controller(None)
+    controller._test_mode = True
+    controller._serial = FakeSerialPort
+    chip = Chip(2, 4)
+    chip2 = Chip(3, 4)
+    controller.multi_read_configuration((chip, chip2))
+    conf_data = chip.get_configuration_packets(Packet.CONFIG_READ_PACKET)
+    conf_data2 = chip2.get_configuration_packets(Packet.CONFIG_READ_PACKET)
+    expected = ' '.join(map(bytes2str, [controller.format_UART(chip, conf_data_i) for
+            conf_data_i in conf_data]))
+    expected2 = ' '.join(map(bytes2str, [controller.format_UART(chip2, conf_data_i) for
+            conf_data_i in conf_data2]))
+    expected += ' ' + expected2
+    result, err = capfd.readouterr()
+    assert result == expected
+
+def test_controller_multi_read_configuration_specify_registers(capfd):
+    controller = Controller(None)
+    controller._test_mode = True
+    controller._serial = FakeSerialPort
+    chip = Chip(2, 4)
+    chip2 = Chip(3, 4)
+    controller.multi_read_configuration([(chip, 0), chip2])
+    conf_data = chip.get_configuration_packets(Packet.CONFIG_READ_PACKET)[:1]
+    conf_data2 = chip2.get_configuration_packets(Packet.CONFIG_READ_PACKET)
+    expected = ' '.join(map(bytes2str, [controller.format_UART(chip, conf_data_i) for
+            conf_data_i in conf_data]))
+    expected2 = ' '.join(map(bytes2str, [controller.format_UART(chip2, conf_data_i) for
+            conf_data_i in conf_data2]))
+    expected += ' ' + expected2
+    result, err = capfd.readouterr()
+    assert result == expected
+
 def test_controller_get_configuration_bytestreams():
     controller = Controller(None)
     chip = Chip(0, 0)

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -1580,6 +1580,40 @@ def test_controller_write_configuration_write_read(capfd):
     result, err = capfd.readouterr()
     assert result == expected
 
+def test_controller_multi_write_configuration(capfd):
+    controller = Controller(None)
+    controller._test_mode = True
+    controller._serial = FakeSerialPort
+    chip = Chip(2, 4)
+    chip2 = Chip(3, 4)
+    controller.multi_write_configuration((chip, chip2))
+    conf_data = chip.get_configuration_packets(Packet.CONFIG_WRITE_PACKET)
+    conf_data2 = chip2.get_configuration_packets(Packet.CONFIG_WRITE_PACKET)
+    expected = ' '.join(map(bytes2str, [controller.format_UART(chip, conf_data_i) for
+            conf_data_i in conf_data]))
+    expected2 = ' '.join(map(bytes2str, [controller.format_UART(chip2, conf_data_i) for
+            conf_data_i in conf_data2]))
+    expected += ' ' + expected2
+    result, err = capfd.readouterr()
+    assert result == expected
+
+def test_controller_multi_write_configuration_specify_registers(capfd):
+    controller = Controller(None)
+    controller._test_mode = True
+    controller._serial = FakeSerialPort
+    chip = Chip(2, 4)
+    chip2 = Chip(3, 4)
+    controller.multi_write_configuration([(chip, 0), chip2])
+    conf_data = chip.get_configuration_packets(Packet.CONFIG_WRITE_PACKET)[:1]
+    conf_data2 = chip2.get_configuration_packets(Packet.CONFIG_WRITE_PACKET)
+    expected = ' '.join(map(bytes2str, [controller.format_UART(chip, conf_data_i) for
+            conf_data_i in conf_data]))
+    expected2 = ' '.join(map(bytes2str, [controller.format_UART(chip2, conf_data_i) for
+            conf_data_i in conf_data2]))
+    expected += ' ' + expected2
+    result, err = capfd.readouterr()
+    assert result == expected
+
 def test_controller_get_configuration_bytestreams():
     controller = Controller(None)
     chip = Chip(0, 0)

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -1617,7 +1617,7 @@ def test_controller_multi_write_configuration_specify_registers(capfd):
 
 def test_controller_multi_read_configuration(capfd):
     controller = Controller(None)
-    controller._test_mode = True
+    controller.use_all_chips = True
     controller._serial = FakeSerialPort
     chip = Chip(2, 4)
     chip2 = Chip(3, 4)
@@ -1634,7 +1634,7 @@ def test_controller_multi_read_configuration(capfd):
 
 def test_controller_multi_read_configuration_specify_registers(capfd):
     controller = Controller(None)
-    controller._test_mode = True
+    controller.use_all_chips = True
     controller._serial = FakeSerialPort
     chip = Chip(2, 4)
     chip2 = Chip(3, 4)


### PR DESCRIPTION
Add new functions, Controller.multi_read_configuration and Controller.multi_write_configuration. This forms a single bytestream with all the desired configuration commands to send out all at once, eliminating the need for repeated calls to write_configuration or read_configuration (which involves many reads/writes and serial port open/close).