### PR TITLE
Change encoding so we can save bytestreams to JSON files without crashing

### DIFF
--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -1332,7 +1332,7 @@ class PacketCollection(object):
         d['message'] = str(self.message)
         d['read_id'] = 'None' if self.read_id is None else self.read_id
         d['bytestream'] = ('None' if self.bytestream is None else
-                self.bytestream.decode('utf-8'))
+                self.bytestream.decode('raw_unicode_escape'))
         return d
 
     def from_dict(self, d):
@@ -1342,7 +1342,7 @@ class PacketCollection(object):
         '''
         self.message = d['message']
         self.read_id = d['read_id']
-        self.bytestream = d['bytestream'].encode('utf-8')
+        self.bytestream = d['bytestream'].encode('raw_unicode_escape')
         self.parent = None
         self.packets = []
         for p in d['packets']:

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -189,7 +189,7 @@ def test_controller_save_output(tmpdir):
                     'parent': 'None',
                     'message': 'hi',
                     'read_id': 0,
-                    'bytestream': p.bytes().decode('utf-8')
+                    'bytestream': p.bytes().decode('raw_unicode_escape')
                     }
                 ]
             }
@@ -1699,6 +1699,7 @@ def test_packetcollection_origin():
 
 def test_packetcollection_to_dict():
     packet = Packet()
+    packet.chipid = 246
     packet.packet_type = Packet.TEST_PACKET
     collection = PacketCollection([packet], bytestream=packet.bytes(),
             message='hello')
@@ -1708,11 +1709,11 @@ def test_packetcollection_to_dict():
             'parent': 'None',
             'message': 'hello',
             'read_id': 'None',
-            'bytestream': packet.bytes().decode('utf-8'),
+            'bytestream': packet.bytes().decode('raw_unicode_escape'),
             'packets': [{
                 'bits': packet.bits.bin,
                 'type': 'test',
-                'chipid': 0,
+                'chipid': packet.chipid,
                 'parity': 0,
                 'valid_parity': True,
                 'counter': 0


### PR DESCRIPTION
Fix #73 by using 'raw_unicode_escape' encoding

This converts between bytes objects and str objects by taking every
character literally, i.e. b'\<whatever\>' <-> '\<whatever\>'.