### PR TITLE
PacketCollection shortcut

### DIFF
--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -1353,8 +1353,37 @@ class PacketCollection(object):
 
     def extract(self, attr, **selection):
         '''
-        Returns a list of the packet.(attr) values
-        A selection can be made on other packet attributes (chipid, valid_parity, etc)
+        Extract the given attribute from packets specified by selection
+        and return a list.
+
+        Any key used in Packet.export is a valid attribute or selection:
+
+        - all packets:
+             - bits
+             - type (data, test, config read, config write)
+             - chipid
+             - parity
+             - valid_parity
+        - data packets:
+             - channel
+             - timestamp
+             - adc_count
+             - fifo_half
+             - fifo_full
+        - test packets:
+             - counter
+        - config packets:
+             - register
+             - value
+
+        Usage:
+
+        >>> # Return a list of adc counts from any data packets
+        >>> adc_data = collection.extract('adc_counts')
+        >>> # Return a list of timestamps from chip 2 data
+        >>> timestamps = collection.extract('timestamp', chipid=2)
+        >>> # Return the most recently read global threshold from chip 5
+        >>> threshold = collection.extract('value', register=32, type='config read', chip=5)[-1]
 
         '''
         values = []

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -1360,9 +1360,10 @@ class PacketCollection(object):
         values = []
         for p in self.packets:
             try:
-                if all( getattr(p, key) == value for key, value in selection.iteritems()):
-                    values.append(getattr(p, attr))
-            except AttributeError:
+                d = p.export()
+                if all( d[key] == value for key, value in selection.iteritems()):
+                    values.append(d[attr])
+            except KeyError:
                 continue
         return values
 

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -1351,6 +1351,21 @@ class PacketCollection(object):
             packet.bits = BitArray('0b' + bits)
             self.packets.append(packet)
 
+    def get_packet_attr(self, attr, **selection):
+        '''
+        Returns a list of the packet.attr values
+        A selection can be made on other packet attributes (chipid, valid_parity, etc)
+
+        '''
+        values = []
+        for p in self.packets:
+            try:
+                if all( getattr(p, key) == value for key, value in selection.iteritems()):
+                    values.append(getattr(p, attr))
+            except AttributeError:
+                continue
+        return values
+
     def origin(self):
         '''
         Return the original PacketCollection that this PacketCollection

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -1361,7 +1361,7 @@ class PacketCollection(object):
         for p in self.packets:
             try:
                 d = p.export()
-                if all( d[key] == value for key, value in selection.iteritems()):
+                if all( d[key] == value for key, value in selection.items()):
                     values.append(d[attr])
             except KeyError:
                 continue

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -1351,9 +1351,9 @@ class PacketCollection(object):
             packet.bits = BitArray('0b' + bits)
             self.packets.append(packet)
 
-    def get_packet_attr(self, attr, **selection):
+    def extract(self, attr, **selection):
         '''
-        Returns a list of the packet.attr values
+        Returns a list of the packet.(attr) values
         A selection can be made on other packet attributes (chipid, valid_parity, etc)
 
         '''

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -1697,6 +1697,25 @@ def test_packetcollection_origin():
     assert second_gen.parent is first_gen
     assert second_gen.origin() is collection
 
+def test_packetcollection_get_packet_attr():
+    p1 = Packet()
+    p1.chipid = 10
+    p1.packet_type = Packet.DATA_PACKET
+    p1.dataword = 36
+    p2 = Packet()
+    p2.chipid = 9
+    p2.packet_type = Packet.DATA_PACKET
+    p2.dataword = 38
+    pc = PacketCollection([p1,p2])
+    expected = [10, 9]
+    assert pc.get_packet_attr('chipid') == expected
+    expected = [36, 38]
+    assert pc.get_packet_attr('dataword') == expected
+    expected = [36]
+    assert pc.get_packet_attr('dataword', chipid=10) == expected
+    expected = []
+    assert pc.get_packet_attr('dataword', packet_type=Packet.TEST_PACKET) == expected
+
 def test_packetcollection_to_dict():
     packet = Packet()
     packet.chipid = 246

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -1716,8 +1716,8 @@ def test_packetcollection_get_packet_attr():
     assert pc.get_packet_attr('adc_counts') == expected
     expected = [36]
     assert pc.get_packet_attr('adc_counts', chipid=10) == expected
-    expected = []
-    assert pc.get_packet_attr('adc_counts', packet_type=Packet.TEST_PACKET) == expected
+    expected = [0]
+    assert pc.get_packet_attr('counter', type='test') == expected
 
 def test_packetcollection_to_dict():
     packet = Packet()

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -1697,7 +1697,7 @@ def test_packetcollection_origin():
     assert second_gen.parent is first_gen
     assert second_gen.origin() is collection
 
-def test_packetcollection_get_packet_attr():
+def test_packetcollection_extract():
     p1 = Packet()
     p1.chipid = 10
     p1.packet_type = Packet.DATA_PACKET
@@ -1711,13 +1711,13 @@ def test_packetcollection_get_packet_attr():
     p3.packet_type = Packet.TEST_PACKET
     pc = PacketCollection([p1,p2,p3])
     expected = [10, 9, 8]
-    assert pc.get_packet_attr('chipid') == expected
+    assert pc.extract('chipid') == expected
     expected = [36, 38]
-    assert pc.get_packet_attr('adc_counts') == expected
+    assert pc.extract('adc_counts') == expected
     expected = [36]
-    assert pc.get_packet_attr('adc_counts', chipid=10) == expected
+    assert pc.extract('adc_counts', chipid=10) == expected
     expected = [0]
-    assert pc.get_packet_attr('counter', type='test') == expected
+    assert pc.extract('counter', type='test') == expected
 
 def test_packetcollection_to_dict():
     packet = Packet()

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -1706,8 +1706,11 @@ def test_packetcollection_get_packet_attr():
     p2.chipid = 9
     p2.packet_type = Packet.DATA_PACKET
     p2.dataword = 38
-    pc = PacketCollection([p1,p2])
-    expected = [10, 9]
+    p3 = Packet()
+    p3.chipid = 8
+    p3.packet_type = Packet.TEST_PACKET
+    pc = PacketCollection([p1,p2,p3])
+    expected = [10, 9, 8]
     assert pc.get_packet_attr('chipid') == expected
     expected = [36, 38]
     assert pc.get_packet_attr('adc_counts') == expected

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -1710,11 +1710,11 @@ def test_packetcollection_get_packet_attr():
     expected = [10, 9]
     assert pc.get_packet_attr('chipid') == expected
     expected = [36, 38]
-    assert pc.get_packet_attr('dataword') == expected
+    assert pc.get_packet_attr('adc_counts') == expected
     expected = [36]
-    assert pc.get_packet_attr('dataword', chipid=10) == expected
+    assert pc.get_packet_attr('adc_counts', chipid=10) == expected
     expected = []
-    assert pc.get_packet_attr('dataword', packet_type=Packet.TEST_PACKET) == expected
+    assert pc.get_packet_attr('adc_counts', packet_type=Packet.TEST_PACKET) == expected
 
 def test_packetcollection_to_dict():
     packet = Packet()


### PR DESCRIPTION
Adds get_packet_attr to PacketCollection to solve issue #72 
Usage:
` collection.get_packet_attr('adc_counts', chipid=246)`
returns a list of the `adc_counts` values for packets with `chipid == 246`.

Known issue:
~~This does not check for packet type, so this will return `packet.dataword` for all packets (not just data packets). The quick fix is just to call `collection.get_packet_attr('dataword', packet_type=Packet.DATA_PACKET)`.~~ Fixed by switching to dict representation of packets.