### PR TITLE
Separate serial port classes for mac/linux

### DIFF
--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -766,7 +766,8 @@ class Controller(object):
                 if self.port:
                     self._serial = guess[0](**serial_kwargs)
                 elif guess[1]:
-                    serial_kwargs['port'] = guess[1]
+                    self.port = guess[1]
+                    serial_kwargs['port'] = self.port
                     self._serial = guess[0](**serial_kwargs)
                 else:
                     raise OSError('Cannot find a port. Guess: %s' % str(guess))

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -754,6 +754,7 @@ class Controller(object):
         self.baudrate = 1000000
         self.timeout = 1
         self.max_write = 8192
+        self.port = port
         serial_kwargs = {
                 'baudrate': self.baudrate,
                 'timeout': self.timeout,
@@ -762,15 +763,15 @@ class Controller(object):
         if guess_port:
             guess = serialport.guess_port()
             if guess is not None:
-                if port:
+                if self.port:
                     self._serial = guess[0](**serial_kwargs)
                 elif guess[1]:
                     serial_kwargs['port'] = guess[1]
                     self._serial = guess[0](**serial_kwargs)
                 else:
-                    raise OSError('Cannot find a port. Guess: %s' % guess)
+                    raise OSError('Cannot find a port. Guess: %s' % str(guess))
             else:
-                raise OSError('Cannot find a port. Guess: %s' % guess)
+                raise OSError('Cannot find a port. Guess: %s' % str(guess))
         self.all_chips = self._init_chips()
         self._serial = serial.Serial
 
@@ -1111,7 +1112,7 @@ class Controller(object):
 
         Overwrites all data inside the controller!
         '''
-        self.__init__(self.port)
+        self.__init__(port=self.port, guess_port=False)
         with open(filename, 'r') as infile:
             data = json.load(infile)
         chip_regexp = re.compile(r'Chip\((\d+), ?(\d+)\)')

--- a/larpix/serialport/__init__.py
+++ b/larpix/serialport/__init__.py
@@ -42,7 +42,7 @@ def _guess_port_mac():
     port_search = ('system_profiler SPUSBDataType | '
             'grep -C 7 FTDI | grep Serial')
     port_search_result = os.popen(port_search).read()
-    if len(port_search_result > 0):
+    if len(port_search_result) > 0:
         start_index = port_search_result.find('Serial Number:')
         port = port_search_result[start_index+14:start_index+24].strip()
     else:

--- a/larpix/serialport/__init__.py
+++ b/larpix/serialport/__init__.py
@@ -40,7 +40,7 @@ def _guess_port_mac():
     import larpix.serialport.libftdi as libFTDISerial
     SerialPort = libFTDISerial.FTDISerialPort
     port_search = ('system_profiler SPUSBDataType | '
-            'grep C 7 FTDI | grep Serial')
+            'grep -C 7 FTDI | grep Serial')
     port_search_result = os.popen(port_search).read()
     if len(port_search_result > 0):
         start_index = port_search_result.find('Serial Number:')

--- a/larpix/serialport/__init__.py
+++ b/larpix/serialport/__init__.py
@@ -28,10 +28,10 @@ def guess_port():
 def _guess_port_linux():
     import larpix.serialport.linux as LinuxSerial
     SerialPort = LinuxSerial.LinuxSerialPort
-    if os.path.exists('/dev/ttyUSB2'):
+    if os.path.exists('/dev/ttyUSB2'):  # Laptop
         port = '/dev/ttyUSB2'
-    elif os.path.exists('/dev/ttyUSB0'):
-        port = '/dev/ttyUSB0'
+    elif os.path.exists('/dev/ttyAMA0'):  # Raspberry Pi
+        port = '/dev/ttyAMA0'
     else:
         port = None
     return (SerialPort, port)

--- a/larpix/serialport/__init__.py
+++ b/larpix/serialport/__init__.py
@@ -1,0 +1,68 @@
+'''
+Pick the appropriate wrapper for serial communications.
+
+'''
+
+def AbstractSerialPort(object):
+    '''
+    Specifies the interface for serial communications.
+
+    '''
+
+    def __init__(self, port, baudrate, timeout):
+        '''
+        Initialize the serial driver and prepare to read or write.
+
+        Implementations may decide to open the serial port here or to
+        open it using __enter__ and __exit__ (context managers).
+
+        Usage:
+
+        >>> serial_port = AbstractSerialPort(port, baudrate, timeout)
+        >>> with serial_port as s:
+        ...     s.read(10)
+        ...     s.write(b'hello')
+
+        Implementations are not guaranteed to work outside of the
+        ``with...as`` context manager, so if your implementation does
+        not require one, write a wrapper for it anyways (or just inherit
+        from this base class).
+
+        '''
+        pass
+
+    def __enter__(self):
+        '''
+        Prepare for a sequence of serial reads or writes.
+
+        By default, this function just returns self (i.e. does nothing).
+
+        '''
+        return self
+
+    def __exit__(self, type, value, traceback):
+        '''
+        Clean up after a sequence of serial reads or writes.
+
+        By default, this function does nothing.
+
+        '''
+        pass
+
+    def read(self, num_bytes):
+        '''
+        Read the specified number of bytes from the serial port.
+
+        If the read takes longer than self.timeout, then abort early and
+        return whatever bytes are there.
+
+        '''
+        pass
+
+    def write(self, bytes_to_write):
+        '''
+        Write the specified bytes to the serial port.
+
+        '''
+        pass
+

--- a/larpix/serialport/libftdi.py
+++ b/larpix/serialport/libftdi.py
@@ -19,9 +19,11 @@ class FTDISerialPort(object):
 
         '''
         self._device = pylibftdi.Device(port)
+        self.baudrate = baudrate
+        self.timeout = timeout
         if self._device.closed:
             self._device.open()
-        self._confirm_baudrate()
+        self._reset_baudrate()
 
     def __del__(self):
         '''
@@ -51,3 +53,8 @@ class FTDISerialPort(object):
 
         '''
         return self._dvice.write(num_bytes)
+
+    def _reset_baudrate():
+        '''Reset the device baudrate to be self.baudrate.'''
+        if self._device.baudrate != self.baudrate:
+            self._device.baudrate = self.baudrate

--- a/larpix/serialport/libftdi.py
+++ b/larpix/serialport/libftdi.py
@@ -1,0 +1,53 @@
+'''
+Uses the libFTDI serial port driver.
+
+'''
+
+import pylibftdi
+
+class FTDISerialPort(object):
+    '''
+    The wrapper class for pylibftdi.Driver.
+
+    Opens the serial port on ``__init__``.
+
+    '''
+
+    def __init__(self, port, baudrate, timeout):
+        '''
+        Initialize the serial port and open it for reading/writing.
+
+        '''
+        self._device = pylibftdi.Device(port)
+        if self._device.closed:
+            self._device.open()
+        self._confirm_baudrate()
+
+    def __del__(self):
+        '''
+        Close the serial port.
+
+        '''
+        self._device.close()
+
+    def __enter__(self):
+        '''Do nothing.'''
+        return self
+
+    def __exit__(self, type, value, traceback):
+        '''Do nothing.'''
+        pass
+
+    def read(self, num_bytes):
+        '''
+        Read the specified number of bytes from the serial port.
+
+        '''
+        return self._device.read(num_bytes)
+
+    def write(self, bytes_to_write):
+        '''
+        Write the specified bytes to the serial port.
+
+        '''
+        return self._dvice.write(num_bytes)

--- a/larpix/serialport/libftdi.py
+++ b/larpix/serialport/libftdi.py
@@ -52,7 +52,7 @@ class FTDISerialPort(object):
         Write the specified bytes to the serial port.
 
         '''
-        return self._dvice.write(num_bytes)
+        return self._device.write(num_bytes)
 
     def _reset_baudrate():
         '''Reset the device baudrate to be self.baudrate.'''

--- a/larpix/serialport/linux.py
+++ b/larpix/serialport/linux.py
@@ -1,0 +1,9 @@
+'''
+The serial port interface for linux computers (including Raspberry Pi).
+
+It is literally just an alias of pyserial's serial.Serial class.
+
+'''
+import serial
+
+LinuxSerialPort = serial.Serial

--- a/larpix/simulation.py
+++ b/larpix/simulation.py
@@ -196,7 +196,7 @@ class MockFormatter(object):
         self.miso_source = None
         self.miso_buffer = deque()
         ''' Represents all buffers between the FPGA and the serial port.'''
-        self._controller = larpix.Controller(None)
+        self._controller = larpix.Controller(port=None, guess_port=False)
         '''Used for its parse_input function.'''
 
     def activate_chips(self):

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -168,7 +168,7 @@ def test_chip_export_reads_all():
     assert chip.new_reads_index == 1
 
 def test_controller_save_output(tmpdir):
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
     chip = Chip(1, 0)
     p = Packet()
     chip.reads.append(p)
@@ -196,7 +196,7 @@ def test_controller_save_output(tmpdir):
     assert result == expected
 
 def test_controller_load(tmpdir):
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
     chip = Chip(1, 0)
     p = Packet()
     p.chipid = 1
@@ -207,7 +207,7 @@ def test_controller_load(tmpdir):
     name = str(tmpdir.join('test.json'))
     expected_message = 'this is a test'
     controller.save_output(name, expected_message)
-    new_controller = Controller(None)
+    new_controller = Controller(port=None, guess_port=False)
     result_message = new_controller.load(name)
     assert result_message == expected_message
     assert new_controller.reads == controller.reads
@@ -1461,26 +1461,26 @@ def test_configuration_from_dict_reg_reset_cycles():
     assert result == expected
 
 def test_controller_init_chips():
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
     result = list(map(repr, controller._init_chips()))
     expected = list(map(repr, (Chip(i, 0) for i in range(256))))
     assert result == expected
 
 def test_controller_get_chip():
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
     chip = Chip(1, 3)
     controller.chips.append(chip)
     assert controller.get_chip(1, 3) == chip
 
 def test_controller_get_chip_all_chips():
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
     controller.use_all_chips = True
     result = controller.get_chip(5, 0)
     expected = controller.all_chips[5]
     assert result == expected
 
 def test_controller_get_chip_error():
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
     chip = Chip(1, 3)
     controller.chips.append(chip)
     with pytest.raises(ValueError, message='Should fail: bad chipid'):
@@ -1489,7 +1489,7 @@ def test_controller_get_chip_error():
         controller.get_chip(1, 1)
 
 def test_controller_serial_read_mock():
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
     controller._serial = FakeSerialPort
     FakeSerialPort.data_to_mock_read = bytes(bytearray(10))
     result = controller.serial_read(0.1)
@@ -1497,7 +1497,7 @@ def test_controller_serial_read_mock():
     assert result == expected
 
 def test_controller_serial_write_mock(capfd):
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
     controller._serial = FakeSerialPort
     to_write = [b's12345678q', b's87654321q']
     controller.serial_write(to_write)
@@ -1506,7 +1506,7 @@ def test_controller_serial_write_mock(capfd):
     assert result == expected
 
 def test_controller_serial_write_read_mock(capfd):
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
     controller._serial = FakeSerialPort
     to_write = [b's12345678q', b's9862983aq']
     FakeSerialPort.data_to_mock_read = bytes(bytearray(range(256)))
@@ -1518,7 +1518,7 @@ def test_controller_serial_write_read_mock(capfd):
     assert write_result == write_expected
 
 def test_controller_format_UART():
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
     chip = Chip(2, 4)
     packet = chip.get_configuration_packets(Packet.CONFIG_READ_PACKET)[10]
     result = controller.format_UART(chip, packet)
@@ -1526,7 +1526,7 @@ def test_controller_format_UART():
     assert result == expected
 
 def test_controller_format_bytestream():
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
     chip = Chip(2, 4)
     packets = chip.get_configuration_packets(Packet.CONFIG_READ_PACKET)
     fpackets = [controller.format_UART(chip, p) for p in packets]
@@ -1542,7 +1542,8 @@ def test_controller_format_bytestream():
     assert result == expected
 
 def test_controller_read_configuration(capfd):
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
+    controller._test_mode = True
     controller._serial = FakeSerialPort
     chip = Chip(2, 0)
     controller.chips.append(chip)
@@ -1557,7 +1558,8 @@ def test_controller_read_configuration(capfd):
     assert result == expected
 
 def test_controller_read_configuration_reg(capfd):
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
+    controller._test_mode = True
     controller._serial = FakeSerialPort
     chip = Chip(2, 0)
     controller.chips.append(chip)
@@ -1570,7 +1572,8 @@ def test_controller_read_configuration_reg(capfd):
     assert result == expected
 
 def test_controller_write_configuration(capfd):
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
+    controller._test_mode = True
     controller._serial = FakeSerialPort
     chip = Chip(2, 4)
     controller.write_configuration(chip)
@@ -1581,7 +1584,7 @@ def test_controller_write_configuration(capfd):
     assert result == expected
 
 def test_controller_write_configuration_one_reg(capfd):
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
     controller._test_mode = True
     controller._serial = FakeSerialPort
     chip = Chip(2, 4)
@@ -1592,7 +1595,7 @@ def test_controller_write_configuration_one_reg(capfd):
     assert result == expected
 
 def test_controller_write_configuration_write_read(capfd):
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
     controller._serial = FakeSerialPort
     controller.timeout=0.01
     chip = Chip(2, 0)
@@ -1608,7 +1611,7 @@ def test_controller_write_configuration_write_read(capfd):
     assert result == expected
 
 def test_controller_multi_write_configuration(capfd):
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
     controller._test_mode = True
     controller._serial = FakeSerialPort
     chip = Chip(2, 4)
@@ -1625,7 +1628,7 @@ def test_controller_multi_write_configuration(capfd):
     assert result == expected
 
 def test_controller_multi_write_configuration_specify_registers(capfd):
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
     controller._test_mode = True
     controller._serial = FakeSerialPort
     chip = Chip(2, 4)
@@ -1643,7 +1646,7 @@ def test_controller_multi_write_configuration_specify_registers(capfd):
 
 
 def test_controller_multi_read_configuration(capfd):
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
     controller.use_all_chips = True
     controller._serial = FakeSerialPort
     chip = Chip(2, 4)
@@ -1660,7 +1663,7 @@ def test_controller_multi_read_configuration(capfd):
     assert result == expected
 
 def test_controller_multi_read_configuration_specify_registers(capfd):
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
     controller.use_all_chips = True
     controller._serial = FakeSerialPort
     chip = Chip(2, 4)
@@ -1677,7 +1680,7 @@ def test_controller_multi_read_configuration_specify_registers(capfd):
     assert result == expected
 
 def test_controller_get_configuration_bytestreams():
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
     chip = Chip(0, 0)
     controller.chips.append(chip)
     result = controller.get_configuration_bytestreams(chip,
@@ -1689,7 +1692,7 @@ def test_controller_get_configuration_bytestreams():
     assert result == expected
 
 def test_controller_parse_input():
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
     chip = Chip(2, 4)
     controller.chips.append(chip)
     packets = chip.get_configuration_packets(Packet.CONFIG_READ_PACKET)
@@ -1701,7 +1704,7 @@ def test_controller_parse_input():
 
 def test_controller_parse_input_dropped_data_byte():
     # Test whether the parser can recover from dropped bytes
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
     chip = Chip(2, 4)
     controller.chips.append(chip)
     packets = chip.get_configuration_packets(Packet.CONFIG_READ_PACKET)
@@ -1715,7 +1718,7 @@ def test_controller_parse_input_dropped_data_byte():
     assert result == expected
 
 def test_controller_parse_input_dropped_start_byte():
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
     chip = Chip(2, 4)
     controller.chips.append(chip)
     packets = chip.get_configuration_packets(Packet.CONFIG_READ_PACKET)
@@ -1729,7 +1732,7 @@ def test_controller_parse_input_dropped_start_byte():
     assert result == expected
 
 def test_controller_parse_input_dropped_stop_byte():
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
     chip = Chip(2, 4)
     controller.chips.append(chip)
     packets = chip.get_configuration_packets(Packet.CONFIG_READ_PACKET)
@@ -1743,7 +1746,7 @@ def test_controller_parse_input_dropped_stop_byte():
     assert result == expected
 
 def test_controller_parse_input_dropped_stopstart_bytes():
-    controller = Controller(None)
+    controller = Controller(port=None, guess_port=False)
     chip = Chip(2, 4)
     controller.chips.append(chip)
     packets = chip.get_configuration_packets(Packet.CONFIG_READ_PACKET)


### PR DESCRIPTION
I wrote a framework to manage the serial port classes separately for mac and for linux.

I'm having trouble getting libftdi working on Patrick's laptop so I can't really test out the mac version on my own. But the linux version works with my computer and with our Pi.