### PR TITLE
Store bytes that caused parsing problems

### DIFF
--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -834,7 +834,7 @@ class Controller(object):
             miso_bytestream = self.serial_write_read(bytestreams,
                     timelimit=write_read)
             packets, skipped = self.parse_input(miso_bytestream)
-            self.store_packets(packets, miso_bytestream, message)
+            self.store_packets(packets, miso_bytestream, skipped, message)
 
     def read_configuration(self, chip, registers=None, timeout=1,
             message=None):
@@ -852,7 +852,7 @@ class Controller(object):
                 Packet.CONFIG_READ_PACKET, registers)
         data = self.serial_write_read(bytestreams, timeout)
         packets, skipped = self.parse_input(data)
-        self.store_packets(packets, data, message)
+        self.store_packets(packets, data, skipped, message)
 
     def multi_write_configuration(self, chip_reg_pairs, write_read=0,
             message=None):
@@ -905,7 +905,7 @@ class Controller(object):
             miso_bytestream = self.serial_write_read(final_bytestream,
                     timelimit=write_read)
             packets, skipped = self.parse_input(miso_bytestream)
-            self.store_packets(packets, miso_bytestream, message)
+            self.store_packets(packets, miso_bytestream, skipped, message)
 
     def multi_read_configuration(self, chip_reg_pairs, timeout=1,
             message=None):
@@ -954,7 +954,7 @@ class Controller(object):
         miso_bytestream = self.serial_write_read(mosi_bytestream,
                 timelimit=timeout)
         packets, skipped = self.parse_input(miso_bytestream)
-        self.store_packets(packets, miso_bytestream, message)
+        self.store_packets(packets, miso_bytestream, skipped, message)
 
     def get_configuration_bytestreams(self, chip, packet_type, registers):
         # The configuration must be sent one register at a time
@@ -971,7 +971,7 @@ class Controller(object):
     def run(self, timelimit, message):
         data = self.serial_read(timelimit)
         packets, skipped = self.parse_input(data)
-        self.store_packets(packets, data, message)
+        self.store_packets(packets, data, skipped, message)
 
     def run_testpulse(self, list_of_channels):
         return
@@ -1025,7 +1025,7 @@ class Controller(object):
                 current_stream = current_stream[next_start_index:]
         return ([x[1] for x in byte_packets], skip_slices)
 
-    def store_packets(self, packets, data, message):
+    def store_packets(self, packets, data, skipped, message):
         '''
         Store the packets in ``self`` and in ``self.chips``
 
@@ -1349,9 +1349,11 @@ class PacketCollection(object):
 
 
     '''
-    def __init__(self, packets, bytestream=None, message='', read_id=None):
+    def __init__(self, packets, bytestream=None, message='',
+            read_id=None, skipped=None):
         self.packets = packets
         self.bytestream = bytestream
+        self.skipped = skipped
         self.message = message
         self.read_id = read_id
         self.parent = None

--- a/larpix/simulation.py
+++ b/larpix/simulation.py
@@ -218,7 +218,7 @@ class MockFormatter(object):
         is 1Mbaud and the LArPix bitrate is 10MHz, i.e. much faster.
 
         '''
-        packets = self._controller.parse_input(data)
+        packets, skipped = self._controller.parse_input(data)
         self.send_mosi(packets)
 
     def receive_miso(self, packet):

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -1543,30 +1543,34 @@ def test_controller_format_bytestream():
 
 def test_controller_read_configuration(capfd):
     controller = Controller(None)
-    controller._test_mode = True
     controller._serial = FakeSerialPort
-    chip = Chip(2, 4)
-    controller.read_configuration(chip)
+    chip = Chip(2, 0)
+    controller.chips.append(chip)
     conf_data = chip.get_configuration_packets(Packet.CONFIG_READ_PACKET)
-    expected = ' '.join(map(bytes2str, [controller.format_UART(chip, conf_data_i) for
-            conf_data_i in conf_data]))
+    expected_bytes = b''.join(controller.format_UART(chip, conf_data_i) for
+            conf_data_i in conf_data)
+    expected = ' '.join(map(bytes2str, [controller.format_UART(chip,
+        conf_data_i) for conf_data_i in conf_data]))
+    FakeSerialPort.data_to_mock_read = expected_bytes
+    controller.read_configuration(chip)
     result, err = capfd.readouterr()
     assert result == expected
 
 def test_controller_read_configuration_reg(capfd):
     controller = Controller(None)
-    controller._test_mode = True
     controller._serial = FakeSerialPort
-    chip = Chip(2, 4)
-    controller.read_configuration(chip, 0)
+    chip = Chip(2, 0)
+    controller.chips.append(chip)
     conf_data = chip.get_configuration_packets(Packet.CONFIG_READ_PACKET)[0]
+    expected_bytes = controller.format_UART(chip, conf_data)
     expected = bytes2str(controller.format_UART(chip, conf_data))
+    FakeSerialPort.data_to_mock_read = expected_bytes
+    controller.read_configuration(chip, 0)
     result, err = capfd.readouterr()
     assert result == expected
 
 def test_controller_write_configuration(capfd):
     controller = Controller(None)
-    controller._test_mode = True
     controller._serial = FakeSerialPort
     chip = Chip(2, 4)
     controller.write_configuration(chip)
@@ -1692,7 +1696,7 @@ def test_controller_parse_input():
     fpackets = [controller.format_UART(chip, p) for p in packets]
     bytestream = b''.join(controller.format_bytestream(fpackets))
     result = controller.parse_input(bytestream)
-    expected = packets
+    expected = (packets, [])
     assert result == expected
 
 def test_controller_parse_input_dropped_data_byte():
@@ -1706,7 +1710,8 @@ def test_controller_parse_input_dropped_data_byte():
     # Drop a byte in the first packet
     bytestream_faulty = bytestream[:5] + bytestream[6:]
     result = controller.parse_input(bytestream_faulty)
-    expected = packets[1:]
+    skipped = [(slice(0, 9), bytestream_faulty[0:9])]
+    expected = (packets[1:], skipped)
     assert result == expected
 
 def test_controller_parse_input_dropped_start_byte():
@@ -1718,8 +1723,9 @@ def test_controller_parse_input_dropped_start_byte():
     bytestream = b''.join(controller.format_bytestream(fpackets))
     # Drop the first start byte
     bytestream_faulty = bytestream[1:]
+    skipped = [(slice(0, 9), bytestream_faulty[0:9])]
     result = controller.parse_input(bytestream_faulty)
-    expected = packets[1:]
+    expected = (packets[1:], skipped)
     assert result == expected
 
 def test_controller_parse_input_dropped_stop_byte():
@@ -1731,8 +1737,9 @@ def test_controller_parse_input_dropped_stop_byte():
     bytestream = b''.join(controller.format_bytestream(fpackets))
     # Drop the first stop byte
     bytestream_faulty = bytestream[:9] + bytestream[10:]
+    skipped = [(slice(0, 9), bytestream_faulty[0:9])]
     result = controller.parse_input(bytestream_faulty)
-    expected = packets[1:]
+    expected = (packets[1:], skipped)
     assert result == expected
 
 def test_controller_parse_input_dropped_stopstart_bytes():
@@ -1744,8 +1751,9 @@ def test_controller_parse_input_dropped_stopstart_bytes():
     bytestream = b''.join(controller.format_bytestream(fpackets))
     # Drop the first stop byte
     bytestream_faulty = bytestream[:9] + bytestream[11:]
+    skipped = [(slice(0, 18), bytestream_faulty[:18])]
     result = controller.parse_input(bytestream_faulty)
-    expected = packets[2:]
+    expected = (packets[2:], skipped)
     assert result == expected
 
 def test_packetcollection_getitem_int():


### PR DESCRIPTION
Issue #23 points out that when there are parsing problems, the problematic bytes are silently discarded. This PR updates ``parse_input`` to return a tuple ``(packets, skipped)``, where ``skipped`` is itself a list of tuples of the form ``(slice(start, end), b'whatever-was-skipped')``. (The slice specifies the location of the skipped bytes in the original bytestring.)

So for standalone calls to ``parse_input``, the skipped bytes can be inspected. For all instances within the library where ``parse_input`` is called, the skipped bytes are added as an attribute to the PacketCollection that stores all of the packets from the particular larpix read.

Fixes #23 