### PR TITLE
Fix bug in Timestamp

### DIFF
--- a/dat2h5.py
+++ b/dat2h5.py
@@ -115,7 +115,11 @@ while True:
                 current_timestamp = Timestamp.from_packet(packet, cpu_time,
                         ref_time)
                 current_array[current_index][8] = current_timestamp.ns
-                last_timestamp[packet.chipid] = current_timestamp
+                if len(last_timestamp.keys())==0:
+                    for chip in range(255):
+                        last_timestamp[chip] = current_timestamp
+                else:
+                    last_timestamp[chipid] = current_timestamp
 
                 if use_root:
                     (root_channelid[0], root_chipid[0], root_pixelid[0],

--- a/larpix/Timestamp.py
+++ b/larpix/Timestamp.py
@@ -123,10 +123,10 @@ class Timestamp(object):
         ``ns == cpu_time * 1e9``)
         - If reference packet has the same ``cpu_time``, add rollovers to ``adj_adc_time``
         until ``ref_time.adj_adc_time < adj_adc_time``
-        - If reference packet has a different ``cpu_time``, add rollovers to ``adc_time``
-        until ``ref_time.adj_adc_time < adj_adc_time``. Then determine the number of rollovers
-        that could have occured between ``cpu_time`` and ``ref_time.cpu_time``, and add to
-        ``adj_adc_time``.
+        - If reference packet has a different ``cpu_time``, estimate the number of clk cycles
+        that have occurred between serial reads add rollovers to ``adj_adc_time`` until the
+        difference between ``ref_time.adj_adc_time`` and ``adj_adc_time`` is less than
+        ``larpix_offset_d/2`` away from the estimated number of clk cycles
         - The previous two steps provide an ``adj_adc_time`` that is serialized, calculate
         ``ns`` from ``ref_time.ns + <diff btw adj_adc_times>/larpix_clk_freq``
 
@@ -134,6 +134,8 @@ class Timestamp(object):
         - within a single serial read, the data rate must be greater than
         ``larpix_clk_freq/larpix_offset_d`` (nominally ~.3Hz) OR the serial timeout must be
         less than ``larpix_offset_d/larpix_clk_freq`` (nominally ~3s)
+        - between serial reads, the first data packet should arrive within
+        ``larpix_offset_d/larpix_clk_freq/2`` of the serial read time (~1.5s)
         - reference time should be the timestamp of the previously read packet from
         that chip (there is a delay between packet creation and packet receipt that can
         interfere with the time ordering of packets between chips)
@@ -151,16 +153,11 @@ class Timestamp(object):
                 adj_adc_time += Timestamp.larpix_offset_d
         else:
             # new serial read
-            while adj_adc_time < ref_time.adj_adc_time:
-                # sychronize adj adc timestamp and ref cpu timestamp
-                adj_adc_time += Timestamp.larpix_offset_d
             # estimate number of clk cycles between reads
-            n_clk_cycles = long((cpu_time - ref_time.cpu_time) * Timestamp.larpix_clk_freq)
-            n_offset = n_clk_cycles // Timestamp.larpix_offset_d
-            adj_adc_time += Timestamp.larpix_offset_d * n_offset
-            # enforce that the n_clk_cycles by adc timestamp is greater than n_clk_cycles
-            # by cpu
-            while adj_adc_time - ref_time.adj_adc_time < n_clk_cycles:
+            n_clk_cycles = long((cpu_time - ref_time.ns * 1e-9) * Timestamp.larpix_clk_freq)
+            # add offsets until you are close to the predicted number of clk cycles
+            while abs(adj_adc_time - ref_time.adj_adc_time - n_clk_cycles) \
+                    > Timestamp.larpix_offset_d / 2:
                 adj_adc_time += Timestamp.larpix_offset_d
 
         timestamp = None

--- a/larpix/datalogger.py
+++ b/larpix/datalogger.py
@@ -64,7 +64,7 @@ class DataLogger(object):
         '''Log a data block'''
         if not self._is_enabled: return
         data_block_desc['block_type'] = 'data'
-        data_block_desc['time'] = time.time()
+        #data_block_desc['time'] = time.time()
         self.buffer += self.formatter.format_block(data_block_desc)
         if len(self.buffer) > self._buffer_flush:
             # Flush current data to file

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -1721,7 +1721,7 @@ class SerialPort(object):
         write_time = time.time()
         self.serial_com.write(data)
         if self.logger:
-            self.logger.record({'data_type':'write','data':data,'time'=write_time})
+            self.logger.record({'data_type':'write','data':data,'time':write_time})
         if not self._keep_open:
             self.close()
         return
@@ -1732,7 +1732,7 @@ class SerialPort(object):
         read_time = time.time()
         data = self.serial_com.read(nbytes)
         if self.logger:
-            self.logger.record({'data_type':'read','data':data,'time'=read_time})
+            self.logger.record({'data_type':'read','data':data,'time':read_time})
         if not self._keep_open:
             self.close()
         return data

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -1718,9 +1718,10 @@ class SerialPort(object):
     def write(self, data):
         '''Write data to serial port'''
         self._ready_port()
+        write_time = time.time()
         self.serial_com.write(data)
         if self.logger:
-            self.logger.record({'data_type':'write','data':data})
+            self.logger.record({'data_type':'write','data':data,'time'=write_time})
         if not self._keep_open:
             self.close()
         return
@@ -1728,9 +1729,10 @@ class SerialPort(object):
     def read(self, nbytes):
         '''Read data from serial port'''
         self._ready_port()
+        read_time = time.time()
         data = self.serial_com.read(nbytes)
         if self.logger:
-            self.logger.record({'data_type':'read','data':data})
+            self.logger.record({'data_type':'read','data':data,'time'=read_time})
         if not self._keep_open:
             self.close()
         return data

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -1906,7 +1906,7 @@ def test_timestamp_ambiguous_rollover():
     t0 = Timestamp.serialized_timestamp(adc_time=5, cpu_time=0)
     t1 = Timestamp.serialized_timestamp(adc_time=6, cpu_time=3,
             ref_time=t0)
-    expected_adj_adc_time = Timestamp.larpix_offset_d + 6
+    expected_adj_adc_time = Timestamp.larpix_offset_d + 1
     expected = \
     Timestamp(ns=expected_adj_adc_time*long(1e9/Timestamp.larpix_clk_freq),
             cpu_time=3, adc_time=6, adj_adc_time=expected_adj_adc_time)

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -1891,3 +1891,23 @@ def test_timestamp_diff_serial_read():
     assert t2_0 == expected
     assert t2_1 == expected
 
+def test_timestamp_ambiguous_rollover():
+    '''
+    This test case checks the following scenario:
+
+      - serial reads every 3s
+      - two triggers mischievously placed 1 + epsilon full cycles apart
+
+    The algorithm must notice that there is a rollover in adc_time due
+    to the discrepancy between ``adc_time_1 - adc_time_0`` (small) and
+    ``cpu_time_1 - cpu_time_0 `` (large), in order to pass this test.
+
+    '''
+    t0 = Timestamp.serialized_timestamp(adc_time=5, cpu_time=0)
+    t1 = Timestamp.serialized_timestamp(adc_time=6, cpu_time=3,
+            ref_time=t0)
+    expected_adj_adc_time = Timestamp.larpix_offset_d + 6
+    expected = \
+    Timestamp(ns=expected_adj_adc_time*long(1e9/Timestamp.larpix_clk_freq),
+            cpu_time=3, adc_time=6, adj_adc_time=expected_adj_adc_time)
+    assert t1 == expected


### PR DESCRIPTION
Updates the Timestamp algorithm to better handle ambiguous timestamps.
Update the Timestamp serialization conditions (packet must arrive <1.5s after the serial read is initiated)
Change datalogger to timestamp at start of serial read instead of at the end.