### PR TITLE
Throw error on calling unknown Configuration register name

### DIFF
--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -189,11 +189,12 @@ class Configuration(object):
 
     def __setattr__(self, name, value):
         '''
-        Default setattr behavior occurs if name is in register name or is "private"
-        Otherwise raise an error
+        Default setattr behavior occurs if name is in ``register_names``, is "private"
+        or is a known attribute
+        Otherwise raises an attribute error
 
         '''
-        if not (name in self.register_names or name[0] == '_'):
+        if not (name in self.register_names or name[0] == '_' or hasattr(self, name)):
             raise AttributeError('%s is not a known register' % name)
         return super(Configuration, self).__setattr__(name, value)
 

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -187,6 +187,16 @@ class Configuration(object):
         # These registers each correspond to an entry in an array
         self._trim_registers = list(range(32))
 
+    def __setattr__(self, name, value):
+        '''
+        Default setattr behavior occurs if name is in register name or is "private"
+        Otherwise raise an error
+
+        '''
+        if not (name in self.register_names or name[0] == '_'):
+            raise AttributeError('%s is not a known register' % name)
+        return super(Configuration, self).__setattr__(name, value)
+
     def __str__(self):
         '''
         Converts configuration to a nicely formatted json string

--- a/test/test_larpix.py
+++ b/test/test_larpix.py
@@ -521,6 +521,12 @@ def test_packet_get_test_counter():
     p.test_counter = expected
     assert p.test_counter == expected
 
+def test_configuration_error_on_unknown_field():
+    c = Configuration()
+    with pytest.raises(AttributeError, message='Should fail: attribute is not in known '
+                       'register names'):
+        c.this_is_a_dummy_attr = 0
+
 def test_configuration_get_nondefault_registers():
     c = Configuration()
     expected = {}


### PR DESCRIPTION
This addresses issue #86. Configuration objects will now raise an attribute error if an attribute is set that is not in the list of `register_names`, variables with an '_' preceding the name, or in the attributes defined in `larpix.py`.