### PR TITLE
Refactor packet code to use bitarray rather than bitstring

### DIFF
--- a/larpix/bitarrayhelper.py
+++ b/larpix/bitarrayhelper.py
@@ -5,10 +5,14 @@ A module with convenience functions for bitarray.
 from bitarray import bitarray
 
 def fromuint(val, nbits):
+    if isinstance(val, bitarray):
+        return val
+    if isinstance(nbits, slice):
+        nbits = abs(nbits.stop - nbits.start)
     bin_string = bin(val)[2:]
     padding = '0' * (nbits - len(bin_string))
     return bitarray(padding + bin_string)
 
 def touint(bits):
-    bin_string = bitarray.to01()
+    bin_string = bits.to01()
     return int(bin_string, 2)

--- a/larpix/bitarrayhelper.py
+++ b/larpix/bitarrayhelper.py
@@ -1,0 +1,14 @@
+'''
+A module with convenience functions for bitarray.
+
+'''
+from bitarray import bitarray
+
+def fromuint(val, nbits):
+    bin_string = bin(val)[2:]
+    padding = '0' * (nbits - len(bin_string))
+    return bitarray(padding + bin_string)
+
+def touint(bits):
+    bin_string = bitarray.to01()
+    return int(bin_string, 2)

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -1191,11 +1191,13 @@ class Controller(object):
         # parse the bytestream into Packets + metadata
         byte_packets = []
         skip_slices = []
-        current_stream = bytestream
+        #current_stream = bytestream
+        bytestream_len = len(bytestream)
+        last_possible_start = bytestream_len - packet_size
         index = 0
-        while len(current_stream) >= packet_size:
-            if (current_stream[0] == start_byte and
-                    current_stream[packet_size-1] == stop_byte):
+        while index <= last_possible_start:
+            if (bytestream[index] == start_byte and
+                    bytestream[index+packet_size-1] == stop_byte):
                 '''
                 metadata = current_stream[metadata_byte_index]
                 # This is necessary because of differences between
@@ -1208,18 +1210,20 @@ class Controller(object):
                     Packet(current_stream[data_bytes])))
                 '''
                 byte_packets.append(([],
-                        Packet(current_stream[data_bytes])))
-                current_stream = current_stream[packet_size:]
+                    Packet(bytestream[index+1:index+8])))
+                #current_stream = current_stream[packet_size:]
                 index += packet_size
             else:
                 # Throw out everything between here and the next start byte.
                 # Note: start searching after byte 0 in case it's
                 # already a start byte
-                next_start_index = current_stream[1:].find(start_byte)
+                index = bytestream.find(start_byte, index+1)
+                if index == -1:
+                    index = bytestream_len
                 #if next_start_index != 0:
                 #        print('Warning: %d extra bytes in data stream!' %
                 #        (next_start_index+1))
-                current_stream = current_stream[1:][next_start_index:]
+                #current_stream = current_stream[1:][next_start_index:]
         #if len(current_stream) != 0:
         #    print('Warning: %d extra bytes at end of data stream!' %
         #          len(current_stream))

--- a/larpix/larpix.py
+++ b/larpix/larpix.py
@@ -1209,8 +1209,7 @@ class Controller(object):
                 byte_packets.append((Bits(code + str(metadata)),
                     Packet(current_stream[data_bytes])))
                 '''
-                byte_packets.append(([],
-                    Packet(bytestream[index+1:index+8])))
+                byte_packets.append(Packet(bytestream[index+1:index+8]))
                 #current_stream = current_stream[packet_size:]
                 index += packet_size
             else:
@@ -1227,7 +1226,7 @@ class Controller(object):
         #if len(current_stream) != 0:
         #    print('Warning: %d extra bytes at end of data stream!' %
         #          len(current_stream))
-        return [x[1] for x in byte_packets]
+        return byte_packets
 
     def store_packets(self, packets, data, message):
         '''

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         keywords='dune physics',
         packages=find_packages(),
         install_requires=['pyserial','bitstring','pytest',
-            'larpix-geometry'],
+            'larpix-geometry', 'bitarray'],
         scripts=['scripts/larpix-drivercheck-ubuntu',
                  'scripts/larpix-drivercheck-mac',
                  'scripts/larpix-find-device-ubuntu',


### PR DESCRIPTION
I replaced all uses of bitstring (``Bits`` and ``BitArray`` objects) with bitarray (``bitarray`` objects). Let's hope this speeds things up. Bitarray is written in C so should be faster…